### PR TITLE
Fix OS X problems

### DIFF
--- a/cord/tests/cordtest.c
+++ b/cord/tests/cordtest.c
@@ -206,9 +206,9 @@ void test_extras(void)
 
 #if defined(__DJGPP__) || defined(__STRICT_ANSI__)
   /* snprintf is missing in DJGPP (v2.0.3) */
-# define GC_SNPRINTF sprintf
-# define GC_SNPRINTF_BUFSZ_ARG(bufsz) /* empty */
+# define HAVE_SNPRINTF 0
 #else
+# define HAVE_SNPRINTF 1
 # if defined(_MSC_VER)
 #   if defined(_WIN32_WCE)
       /* _snprintf is deprecated in WinCE */
@@ -219,7 +219,6 @@ void test_extras(void)
 # else
 #   define GC_SNPRINTF snprintf
 # endif
-# define GC_SNPRINTF_BUFSZ_ARG(bufsz) (bufsz),
 #endif
 
 void test_printf(void)
@@ -244,8 +243,12 @@ void test_printf(void)
     x = CORD_cat(x,x);
     if (CORD_sprintf(&result, "->%-120.78r!\n", x) != 124)
         ABORT("CORD_sprintf failed 3");
-    (void)GC_SNPRINTF(result2, GC_SNPRINTF_BUFSZ_ARG(sizeof(result2))
-                      "->%-120.78s!\n", CORD_to_char_star(x));
+#   if HAVE_SNPRINTF
+        (void)GC_SNPRINTF(result2, sizeof(result2), "->%-120.78s!\n",
+                          CORD_to_char_star(x));
+#   else
+        (void)sprintf(result2, "->%-120.78s!\n", CORD_to_char_star(x));
+#   endif
     result2[sizeof(result2) - 1] = '\0';
     if (CORD_cmp(result, result2) != 0)ABORT("CORD_sprintf goofed 5");
 }

--- a/tests/test.c
+++ b/tests/test.c
@@ -1881,7 +1881,7 @@ int main(void)
 #   if defined(GC_IRIX_THREADS) || defined(GC_FREEBSD_THREADS) \
         || defined(GC_DARWIN_THREADS) || defined(GC_AIX_THREADS) \
         || defined(GC_OPENBSD_THREADS)
-        if ((code = pthread_attr_setstacksize(&attr, 1000000)) != 0) {
+        if ((code = pthread_attr_setstacksize(&attr, 1000*1024)) != 0) {
           GC_printf("pthread_attr_setstacksize failed, error=%d\n", code);
           FAIL;
         }


### PR DESCRIPTION
Fix problems reported on mailing list by John Leung john at johnleung.com 

https://lists.opendylan.org/pipermail/bdwgc/2014-December/006066.html

Explanation of problems and fixes:

There are actually two problems here.

The first is in:

7bef74b Fix unresolved vsnprintf in misc.c and snprintf in cordtest (DJGPP,
VC)

OS X for some reason has problems with defining snprintf as a macro and
including another macro expansion in its arguments. Others have found this
in the past e.g.

http://sourceforge.net/p/powerwatershed/discussion/1024808/thread/79db23d3/

The next problem is in:

0d147af Fix missing error handling of pthread_attr_init/getstacksize

Error 22 is EINVAL.  Man pthread_attr_setstacksize gives the following
possible reasons for EINVAL:

     [EINVAL]           Invalid value for attr.
     [EINVAL]           stacksize is less than PTHREAD_STACK_MIN.
     [EINVAL]           stacksize is not a multiple of the system page size.

Changing the requested stack size from 1000000 to 1000*1024 fixes the problem, demonstrating that the issue is "stacksize is not a multiple of the system page size."
