### PR TITLE
Thread local allocation for typed objects

### DIFF
--- a/include/gc_inline.h
+++ b/include/gc_inline.h
@@ -47,6 +47,16 @@
 /* traced even if objects are ptrfree.                                  */
 GC_API void GC_CALL GC_generic_malloc_many(size_t /* lb */, int /* k */,
                                            void ** /* result */);
+/* Generic allocation function.  Chooses appropriately the thread local */
+/* or the global freelist for the correct kind, then returns a pointer  */
+/* to the alloc'd memory                                                */
+GC_API void * GC_CALL GC_generic_malloc_kind(size_t /* lb */,
+                                             int /* k */);
+#ifdef THREAD_LOCAL_ALLOC
+/* Define the global version in case thread local allocation is enabled */
+GC_API void * GC_CALL GC_generic_malloc_kind_global(size_t /* lb */,
+                                                    int /* k */);
+#endif
 
 /* The ultimately general inline allocation macro.  Allocate an object  */
 /* of size granules, putting the resulting pointer in result.  Tiny_fl  */

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -296,6 +296,7 @@ typedef char * ptr_t;   /* A generic pointer to which we can add        */
 # define MAX_EXTRA_BYTES 0
 #endif
 
+#define TYPD_EXTRA_BYTES (sizeof(word) - EXTRA_BYTES)
 
 # ifndef LARGE_CONFIG
 #   define MINHINCR 16   /* Minimum heap increment, in blocks of HBLKSIZE  */
@@ -1880,8 +1881,6 @@ GC_INNER ptr_t GC_allocobj(size_t sz, int kind);
 
 /* Allocation routines that bypass the thread local cache.      */
 #ifdef THREAD_LOCAL_ALLOC
-  GC_INNER void * GC_core_malloc(size_t);
-  GC_INNER void * GC_core_malloc_atomic(size_t);
 # ifdef GC_GCJ_SUPPORT
     GC_INNER void * GC_core_gcj_malloc(size_t, void *);
 # endif

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -81,6 +81,7 @@
 typedef GC_word word;
 typedef GC_signed_word signed_word;
 typedef unsigned int unsigned32;
+typedef GC_word GC_descr;
 
 typedef int GC_bool;
 #define TRUE 1
@@ -769,6 +770,10 @@ GC_EXTERN GC_warn_proc GC_current_warn_proc;
 #define CPP_MAXOBJGRANULES BYTES_TO_GRANULES(CPP_MAXOBJBYTES)
 #define MAXOBJGRANULES ((size_t)CPP_MAXOBJGRANULES)
 
+#ifndef MAXOBJKINDS
+# define MAXOBJKINDS 16
+#endif
+
 # define divHBLKSZ(n) ((n) >> LOG_HBLKSIZE)
 
 # define HBLK_PTR_DIFF(p,q) divHBLKSZ((ptr_t)p - (ptr_t)q)
@@ -1210,31 +1215,12 @@ struct _GC_arrays {
                 /* calling stack.                                       */
 # endif
 # ifndef SEPARATE_GLOBALS
-#   define GC_objfreelist GC_arrays._objfreelist
-    void *_objfreelist[MAXOBJGRANULES+1];
-                          /* free list for objects */
-#   define GC_aobjfreelist GC_arrays._aobjfreelist
-    void *_aobjfreelist[MAXOBJGRANULES+1];
-                          /* free list for atomic objs  */
-# endif
-  void *_uobjfreelist[MAXOBJGRANULES+1];
-                          /* Uncollectible but traced objs      */
-                          /* objects on this and auobjfreelist  */
-                          /* are always marked, except during   */
-                          /* garbage collections.               */
-# ifdef GC_ATOMIC_UNCOLLECTABLE
-#   define GC_auobjfreelist GC_arrays._auobjfreelist
-    void *_auobjfreelist[MAXOBJGRANULES+1];
-                        /* Atomic uncollectible but traced objs */
+#   define GC_freelist GC_arrays._freelist
+    void *_freelist[MAXOBJKINDS][MAXOBJGRANULES+1];
 # endif
   size_t _size_map[MAXOBJBYTES+1];
         /* Number of granules to allocate when asked for a certain      */
         /* number of bytes.                                             */
-# ifdef STUBBORN_ALLOC
-#   define GC_sobjfreelist GC_arrays._sobjfreelist
-    ptr_t _sobjfreelist[MAXOBJGRANULES+1];
-                          /* Free list for immutable objects.   */
-# endif
 # ifdef MARK_BIT_PER_GRANULE
 #   define GC_obj_map GC_arrays._obj_map
     short * _obj_map[MAXOBJGRANULES+1];
@@ -1336,15 +1322,12 @@ GC_API_PRIV GC_FAR struct _GC_arrays GC_arrays;
 #define GC_size_map GC_arrays._size_map
 #define GC_static_roots GC_arrays._static_roots
 #define GC_top_index GC_arrays._top_index
-#define GC_uobjfreelist GC_arrays._uobjfreelist
 #define GC_valid_offsets GC_arrays._valid_offsets
 
 #define beginGC_arrays ((ptr_t)(&GC_arrays))
 #define endGC_arrays (((ptr_t)(&GC_arrays)) + (sizeof GC_arrays))
 #define USED_HEAP_SIZE (GC_heapsize - GC_large_free_bytes)
 
-/* Object kinds: */
-#define MAXOBJKINDS 16
 
 GC_EXTERN struct obj_kind {
    void **ok_freelist;  /* Array of free listheaders for this kind of object */

--- a/include/private/thread_local_alloc.h
+++ b/include/private/thread_local_alloc.h
@@ -26,8 +26,6 @@
 
 #ifdef THREAD_LOCAL_ALLOC
 
-#include "gc_inline.h"
-
 #if defined(USE_HPUX_TLS)
 # error USE_HPUX_TLS macro was replaced by USE_COMPILER_TLS
 #endif
@@ -78,10 +76,8 @@
 /* One of these should be declared as the tlfs field in the     */
 /* structure pointed to by a GC_thread.                         */
 typedef struct thread_local_freelists {
-  void * ptrfree_freelists[TINY_FREELISTS];
-  void * normal_freelists[TINY_FREELISTS];
+  void * freelists[MAXOBJKINDS][TINY_FREELISTS];
 # ifdef GC_GCJ_SUPPORT
-    void * gcj_freelists[TINY_FREELISTS];
 #   define ERROR_FL ((void *)(word)-1)
         /* Value used for gcj_freelist[-1]; allocation is       */
         /* erroneous.                                           */

--- a/malloc.c
+++ b/malloc.c
@@ -244,12 +244,12 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_generic_malloc(size_t lb, int k)
         GC_DBG_COLLECT_AT_MALLOC(lb);
         lg = GC_size_map[lb];
         LOCK();
-        op = GC_aobjfreelist[lg];
+        op = GC_freelist[PTRFREE][lg];
         if (EXPECT(0 == op, FALSE)) {
             UNLOCK();
             return(GENERAL_MALLOC((word)lb, PTRFREE));
         }
-        GC_aobjfreelist[lg] = obj_link(op);
+        GC_freelist[PTRFREE][lg] = obj_link(op);
         GC_bytes_allocd += GRANULES_TO_BYTES(lg);
         UNLOCK();
         return((void *) op);
@@ -273,7 +273,7 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_generic_malloc(size_t lb, int k)
         GC_DBG_COLLECT_AT_MALLOC(lb);
         lg = GC_size_map[lb];
         LOCK();
-        op = GC_objfreelist[lg];
+        op = GC_freelist[NORMAL][lg];
         if (EXPECT(0 == op, FALSE)) {
             UNLOCK();
             return (GENERAL_MALLOC((word)lb, NORMAL));
@@ -283,7 +283,7 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_generic_malloc(size_t lb, int k)
                         <= (word)GC_greatest_plausible_heap_addr
                      && (word)obj_link(op)
                         >= (word)GC_least_plausible_heap_addr));
-        GC_objfreelist[lg] = obj_link(op);
+        GC_freelist[NORMAL][lg] = obj_link(op);
         obj_link(op) = 0;
         GC_bytes_allocd += GRANULES_TO_BYTES(lg);
         UNLOCK();
@@ -307,9 +307,9 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_malloc_uncollectable(size_t lb)
                   /* collected anyway.                                  */
         lg = GC_size_map[lb];
         LOCK();
-        op = GC_uobjfreelist[lg];
+        op = GC_freelist[UNCOLLECTABLE][lg];
         if (EXPECT(op != 0, TRUE)) {
-            GC_uobjfreelist[lg] = obj_link(op);
+            GC_freelist[UNCOLLECTABLE][lg] = obj_link(op);
             obj_link(op) = 0;
             GC_bytes_allocd += GRANULES_TO_BYTES(lg);
             /* Mark bit ws already set on free list.  It will be        */

--- a/mallocx.c
+++ b/mallocx.c
@@ -39,12 +39,12 @@
 /* Some externally visible but unadvertised variables to allow access to */
 /* free lists from inlined allocators without including gc_priv.h        */
 /* or introducing dependencies on internal data structure layouts.       */
-void ** const GC_objfreelist_ptr = GC_objfreelist;
-void ** const GC_aobjfreelist_ptr = GC_aobjfreelist;
-void ** const GC_uobjfreelist_ptr = GC_uobjfreelist;
-# ifdef GC_ATOMIC_UNCOLLECTABLE
-    void ** const GC_auobjfreelist_ptr = GC_auobjfreelist;
-# endif
+    void ** const GC_objfreelist_ptr = GC_freelist[NORMAL];
+    void ** const GC_aobjfreelist_ptr = GC_freelist[PTRFREE];
+    void ** const GC_uobjfreelist_ptr = GC_freelist[UNCOLLECTABLE];
+#   ifdef GC_ATOMIC_UNCOLLECTABLE
+      void ** const GC_auobjfreelist_ptr = GC_freelist[AUNCOLLECTABLE];
+#   endif
 
 GC_API int GC_CALL GC_get_kind_and_size(const void * p, size_t * psize)
 {

--- a/mark.c
+++ b/mark.c
@@ -47,25 +47,25 @@ GC_INNER unsigned GC_n_mark_procs = GC_RESERVED_MARK_PROCS;
 /* GC_init is called.                                                   */
 /* It's done here, since we need to deal with mark descriptors.         */
 GC_INNER struct obj_kind GC_obj_kinds[MAXOBJKINDS] = {
-/* PTRFREE */ { &GC_aobjfreelist[0], 0 /* filled in dynamically */,
+/* PTRFREE */ { &GC_freelist[PTRFREE][0], 0 /* filled in dynamically */,
                 0 | GC_DS_LENGTH, FALSE, FALSE
                 /*, */ OK_DISCLAIM_INITZ },
-/* NORMAL  */ { &GC_objfreelist[0], 0,
+/* NORMAL  */ { &GC_freelist[NORMAL][0], 0,
                 0 | GC_DS_LENGTH,  /* Adjusted in GC_init for EXTRA_BYTES */
                 TRUE /* add length to descr */, TRUE
                 /*, */ OK_DISCLAIM_INITZ },
 /* UNCOLLECTABLE */
-              { &GC_uobjfreelist[0], 0,
+              { &GC_freelist[UNCOLLECTABLE][0], 0,
                 0 | GC_DS_LENGTH, TRUE /* add length to descr */, TRUE
                 /*, */ OK_DISCLAIM_INITZ },
 # ifdef GC_ATOMIC_UNCOLLECTABLE
    /* AUNCOLLECTABLE */
-              { &GC_auobjfreelist[0], 0,
+              { &GC_freelist[AUNCOLLECTABLE][0], 0,
                 0 | GC_DS_LENGTH, FALSE /* add length to descr */, FALSE
                 /*, */ OK_DISCLAIM_INITZ },
 # endif
 # ifdef STUBBORN_ALLOC
-/*STUBBORN*/ { (void **)&GC_sobjfreelist[0], 0,
+/*STUBBORN*/ { (void **)&GC_freelist[STUBBORN][0], 0,
                 0 | GC_DS_LENGTH, TRUE /* add length to descr */, TRUE
                 /*, */ OK_DISCLAIM_INITZ },
 # endif

--- a/thread_local_alloc.c
+++ b/thread_local_alloc.c
@@ -12,6 +12,11 @@
  */
 
 #include "private/gc_priv.h"
+#include "gc_inline.h"
+
+#ifdef GC_GCJ_SUPPORT
+# include "gc_gcj.h"
+#endif
 
 #if defined(THREAD_LOCAL_ALLOC)
 
@@ -99,7 +104,7 @@ static void return_freelists(void **fl, void **gfl)
 /* This call must be made from the new thread.  */
 GC_INNER void GC_init_thread_local(GC_tlfs p)
 {
-    int i;
+    int i, j;
 
     GC_ASSERT(I_HOLD_LOCK());
     if (!EXPECT(keys_initialized, TRUE)) {
@@ -112,40 +117,40 @@ GC_INNER void GC_init_thread_local(GC_tlfs p)
     if (0 != GC_setspecific(GC_thread_key, p)) {
         ABORT("Failed to set thread specific allocation pointers");
     }
-    for (i = 1; i < TINY_FREELISTS; ++i) {
-        p -> ptrfree_freelists[i] = (void *)(word)1;
-        p -> normal_freelists[i] = (void *)(word)1;
+    for (i = 0; i < MAXOBJKINDS; ++i) {
+        for (j = 1; j < TINY_FREELISTS; ++j) {
+            p->freelists[i][j] = (void *)(word)1;
+        }
+        /* Set up the size 0 free lists.    */
+        /* We now handle most of them like regular free lists, to ensure    */
+        /* That explicit deallocation works.  However, allocation of a      */
+        /* size 0 "gcj" object is always an error.                          */
 #       ifdef GC_GCJ_SUPPORT
-          p -> gcj_freelists[i] = (void *)(word)1;
+            if (i == GC_gcj_kind) {
+                p->freelists[i][0] = ERROR_FL;
+            } else {
 #       endif
-#       ifdef ENABLE_DISCLAIM
-          p -> finalized_freelists[i] = (void *)(word)1;
-#       endif
+        /* else */ {
+            p->freelists[i][0] = (void *)(word)1;
+        }
     }
-    /* Set up the size 0 free lists.    */
-    /* We now handle most of them like regular free lists, to ensure    */
-    /* That explicit deallocation works.  However, allocation of a      */
-    /* size 0 "gcj" object is always an error.                          */
-    p -> ptrfree_freelists[0] = (void *)(word)1;
-    p -> normal_freelists[0] = (void *)(word)1;
-#   ifdef GC_GCJ_SUPPORT
-        p -> gcj_freelists[0] = ERROR_FL;
-#   endif
 #   ifdef ENABLE_DISCLAIM
-        p -> finalized_freelists[0] = (void *)(word)1;
+        for (i = 0; i < TINY_FREELISTS; ++i) {
+            p -> finalized_freelists[i] = (void *)(word)1;
+        }
+        p->finalized_freelists[0] = (void *)(word)1;
 #   endif
 }
 
 /* We hold the allocator lock.  */
 GC_INNER void GC_destroy_thread_local(GC_tlfs p)
 {
+    int i;
     /* We currently only do this from the thread itself or from */
     /* the fork handler for a child process.                    */
-    return_freelists(p -> ptrfree_freelists, GC_aobjfreelist);
-    return_freelists(p -> normal_freelists, GC_objfreelist);
-#   ifdef GC_GCJ_SUPPORT
-        return_freelists(p -> gcj_freelists, (void **)GC_gcjobjfreelist);
-#   endif
+    for (i = 0; i < MAXOBJKINDS; ++i) {
+        return_freelists(p->freelists[i], GC_freelist[i]);
+    }
 #   ifdef ENABLE_DISCLAIM
         return_freelists(p -> finalized_freelists,
                          (void **)GC_finalized_objfreelist);
@@ -184,7 +189,7 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_malloc(size_t bytes)
 
     GC_ASSERT(GC_is_thread_tsd_valid(tsd));
 
-    tiny_fl = ((GC_tlfs)tsd) -> normal_freelists;
+    tiny_fl = ((GC_tlfs)tsd) -> freelists[NORMAL];
     GC_FAST_MALLOC_GRANS(result, granules, tiny_fl, DIRECT_GRANULES,
                          NORMAL, GC_core_malloc(bytes), obj_link(result)=0);
 #   ifdef LOG_ALLOCS
@@ -218,7 +223,7 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_malloc_atomic(size_t bytes)
       }
 #   endif
     GC_ASSERT(GC_is_initialized);
-    tiny_fl = ((GC_tlfs)tsd) -> ptrfree_freelists;
+    tiny_fl = ((GC_tlfs)tsd) -> freelists[PTRFREE];
     GC_FAST_MALLOC_GRANS(result, granules, tiny_fl, DIRECT_GRANULES, PTRFREE,
                          GC_core_malloc_atomic(bytes), (void)0 /* no init */);
     return result;
@@ -259,7 +264,7 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_gcj_malloc(size_t bytes,
     size_t granules = ROUNDED_UP_GRANULES(bytes);
     void *result;
     void **tiny_fl = ((GC_tlfs)GC_getspecific(GC_thread_key))
-                                        -> gcj_freelists;
+                                        -> freelists[GC_gcj_kind];
     GC_ASSERT(GC_gcj_malloc_initialized);
     GC_FAST_MALLOC_GRANS(result, granules, tiny_fl, DIRECT_GRANULES,
                          GC_gcj_kind,
@@ -298,24 +303,20 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_gcj_malloc(size_t bytes,
 GC_INNER void GC_mark_thread_local_fls_for(GC_tlfs p)
 {
     ptr_t q;
-    int j;
+    int i, j;
 
-    for (j = 0; j < TINY_FREELISTS; ++j) {
-      q = p -> ptrfree_freelists[j];
-      if ((word)q > HBLKSIZE) GC_set_fl_marks(q);
-      q = p -> normal_freelists[j];
-      if ((word)q > HBLKSIZE) GC_set_fl_marks(q);
-#     ifdef GC_GCJ_SUPPORT
-        if (j > 0) {
-          q = p -> gcj_freelists[j];
-          if ((word)q > HBLKSIZE) GC_set_fl_marks(q);
+    for (i = 0; i < MAXOBJKINDS; ++i) {
+        for (j = 0; j < TINY_FREELISTS; ++j) {
+            q = p->freelists[i][j];
+#           ifdef GC_GCJ_SUPPORT
+                if (j > 0) {
+                    if ((word)q > HBLKSIZE) GC_set_fl_marks(q);
+                } else
+#           endif /* GC_GCJ_SUPPORT */
+            /* else */ {
+                if ((word)q > HBLKSIZE) GC_set_fl_marks(q);
+            }
         }
-#     endif /* GC_GCJ_SUPPORT */
-#     ifdef ENABLE_DISCLAIM
-        q = p -> finalized_freelists[j];
-        if ((word)q > HBLKSIZE)
-          GC_set_fl_marks(q);
-#     endif
     }
 }
 
@@ -323,17 +324,15 @@ GC_INNER void GC_mark_thread_local_fls_for(GC_tlfs p)
     /* Check that all thread-local free-lists in p are completely marked. */
     void GC_check_tls_for(GC_tlfs p)
     {
-        int j;
+        int i, j;
 
         for (j = 1; j < TINY_FREELISTS; ++j) {
-          GC_check_fl_marks(&p->ptrfree_freelists[j]);
-          GC_check_fl_marks(&p->normal_freelists[j]);
-#         ifdef GC_GCJ_SUPPORT
-            GC_check_fl_marks(&p->gcj_freelists[j]);
-#         endif
-#         ifdef ENABLE_DISCLAIM
-            GC_check_fl_marks(&p->finalized_freelists[j]);
-#         endif
+            for (i = 0; i < MAXOBJKINDS; ++i) {
+                GC_check_fl_marks(&p->freelists[i][j]);
+            }
+#           ifdef ENABLE_DISCLAIM
+                GC_check_fl_marks(&p->finalized_freelists[j]);
+#           endif
         }
     }
 #endif /* GC_ASSERTIONS */

--- a/typd_mlc.c
+++ b/typd_mlc.c
@@ -14,6 +14,7 @@
  */
 
 #include "private/gc_pmark.h"
+#include "gc_inline.h"
 
 /*
  * Some simple primitives for allocation with explicit type information.
@@ -38,8 +39,6 @@
  */
 
 #include "gc_typed.h"
-
-#define TYPD_EXTRA_BYTES (sizeof(word) - EXTRA_BYTES)
 
 STATIC int GC_explicit_kind = 0;
                         /* Object kind for objects with indirect        */
@@ -596,37 +595,17 @@ GC_API GC_descr GC_CALL GC_make_descriptor(const GC_word * bm, size_t len)
 GC_API GC_ATTR_MALLOC void * GC_CALL GC_malloc_explicitly_typed(size_t lb,
                                                                 GC_descr d)
 {
-    ptr_t op;
-    size_t lg;
-    DCL_LOCK_STATE;
-
-    GC_ASSERT(GC_explicit_typing_initialized);
+    void *result;
+    size_t granules;
     lb += TYPD_EXTRA_BYTES;
+    result = GC_generic_malloc_kind(lb, GC_explicit_kind);
     if (SMALL_OBJ(lb)) {
-        GC_DBG_COLLECT_AT_MALLOC(lb);
-        lg = GC_size_map[lb];
-        LOCK();
-        op = GC_eobjfreelist[lg];
-        if (EXPECT(0 == op, FALSE)) {
-            UNLOCK();
-            op = (ptr_t)GENERAL_MALLOC((word)lb, GC_explicit_kind);
-            if (0 == op) return 0;
-            lg = GC_size_map[lb];       /* May have been uninitialized. */
-        } else {
-            GC_eobjfreelist[lg] = obj_link(op);
-            obj_link(op) = 0;
-            GC_bytes_allocd += GRANULES_TO_BYTES(lg);
-            UNLOCK();
-        }
-        ((word *)op)[GRANULES_TO_WORDS(lg) - 1] = d;
-   } else {
-       op = (ptr_t)GENERAL_MALLOC((word)lb, GC_explicit_kind);
-       if (op != NULL) {
-            lg = BYTES_TO_GRANULES(GC_size(op));
-            ((word *)op)[GRANULES_TO_WORDS(lg) - 1] = d;
-       }
-   }
-   return((void *) op);
+        granules = GC_size_map[lb];
+    } else {
+        granules = BYTES_TO_GRANULES(GC_size(result));
+    }
+    ((word *)result)[GRANULES_TO_WORDS(granules) - 1] = d;
+    return result;
 }
 
 GC_API GC_ATTR_MALLOC void * GC_CALL


### PR DESCRIPTION
Hi Ivan,
I am working for Prolog Development Center in an effort to improve the performance of multi-threaded code. We found that the thread local storage was organized a bit differently from the global storage, and hence we refactored some of it so that the global and the local storages would be similar to eachother, and moved some repeated functions into gc_inline.h. Finally, we have implemented the thread local version of the typed allocation.

We successfully tested the code and it is working well in our configuration, compiled under Visual Studio 2013. We also tried to ensure that the code would compile under all other combinations of flags that we touched, but we have not tried to run it in those cases.

We would be very happy if you could review the changes and possibly accept them, and have in our queue two other requests: a stress test for the garbage collector, which I first need to convert to C (you can find the C++ version in my repository) and possibly a memory profiler.