### PR TITLE
GC_malloc_explicitly_typed generalization with kind

### DIFF
--- a/include/gc_mark.h
+++ b/include/gc_mark.h
@@ -163,18 +163,12 @@ GC_API size_t GC_debug_header_size;
 /* custom mark procedures, by language runtimes.                        */
 /* The _inner versions assume the caller holds the allocation lock.     */
 
-/* Return a new free list array.        */
-GC_API void ** GC_CALL GC_new_free_list(void);
-GC_API void ** GC_CALL GC_new_free_list_inner(void);
-
 /* Return a new kind, as specified. */
-GC_API unsigned GC_CALL GC_new_kind(void ** /* free_list */,
-                            GC_word /* mark_descriptor_template */,
+GC_API unsigned GC_CALL GC_new_kind(GC_word /* mark_descriptor_template */,
                             int /* add_size_to_descriptor */,
                             int /* clear_new_objects */) GC_ATTR_NONNULL(1);
                 /* The last two parameters must be zero or one. */
-GC_API unsigned GC_CALL GC_new_kind_inner(void ** /* free_list */,
-                            GC_word /* mark_descriptor_template */,
+GC_API unsigned GC_CALL GC_new_kind_inner(GC_word /* mark_descriptor_template */,
                             int /* add_size_to_descriptor */,
                             int /* clear_new_objects */) GC_ATTR_NONNULL(1);
 

--- a/misc.c
+++ b/misc.c
@@ -1818,29 +1818,7 @@ GC_API int GC_CALL GC_is_disabled(void)
     return GC_dont_gc != 0;
 }
 
-/* Helper procedures for new kind creation.     */
-GC_API void ** GC_CALL GC_new_free_list_inner(void)
-{
-    void *result;
-
-    GC_ASSERT(I_HOLD_LOCK());
-    result = GC_INTERNAL_MALLOC((MAXOBJGRANULES+1) * sizeof(ptr_t), PTRFREE);
-    if (NULL == result) ABORT("Failed to allocate freelist for new kind");
-    BZERO(result, (MAXOBJGRANULES+1)*sizeof(ptr_t));
-    return result;
-}
-
-GC_API void ** GC_CALL GC_new_free_list(void)
-{
-    void *result;
-    DCL_LOCK_STATE;
-    LOCK();
-    result = GC_new_free_list_inner();
-    UNLOCK();
-    return result;
-}
-
-GC_API unsigned GC_CALL GC_new_kind_inner(void **fl, GC_word descr,
+GC_API unsigned GC_CALL GC_new_kind_inner(GC_word descr,
                                           int adjust, int clear)
 {
     unsigned result = GC_n_kinds;
@@ -1849,7 +1827,7 @@ GC_API unsigned GC_CALL GC_new_kind_inner(void **fl, GC_word descr,
     GC_ASSERT(clear == FALSE || clear == TRUE);
     if (result < MAXOBJKINDS) {
       GC_n_kinds++;
-      GC_obj_kinds[result].ok_freelist = fl;
+      GC_obj_kinds[result].ok_freelist = GC_freelists[result];
       GC_obj_kinds[result].ok_reclaim_list = 0;
       GC_obj_kinds[result].ok_descriptor = descr;
       GC_obj_kinds[result].ok_relocate_descr = adjust;
@@ -1864,13 +1842,13 @@ GC_API unsigned GC_CALL GC_new_kind_inner(void **fl, GC_word descr,
     return result;
 }
 
-GC_API unsigned GC_CALL GC_new_kind(void **fl, GC_word descr, int adjust,
+GC_API unsigned GC_CALL GC_new_kind(GC_word descr, int adjust,
                                     int clear)
 {
     unsigned result;
     DCL_LOCK_STATE;
     LOCK();
-    result = GC_new_kind_inner(fl, descr, adjust, clear);
+    result = GC_new_kind_inner(descr, adjust, clear);
     UNLOCK();
     return result;
 }


### PR DESCRIPTION
Generalize GC_malloc_explicitly_typed by calling GC_malloc_kind.  This
will also enable thread local allocation of typed memory.

The same kind of generalization should probably be made for
GC_calloc_explicitly_typed and
GC_malloc_explicitly_typed_ignore_off_page, but we don't use these, so
we cannot validate it.