### PR TITLE
Synchronize variable assignment semantic 

### DIFF
--- a/pthread_support.c
+++ b/pthread_support.c
@@ -460,7 +460,6 @@ STATIC pthread_t GC_mark_threads[MAX_MARKERS];
         break;
       }
     }
-    GC_markers_m1 = i;
 
 #   ifndef NO_MARKER_SPECIAL_SIGMASK
       /* Restore previous signal mask.  */
@@ -470,6 +469,7 @@ STATIC pthread_t GC_mark_threads[MAX_MARKERS];
       }
 #   endif
 
+    GC_markers_m1 = i;
     (void)pthread_attr_destroy(&attr);
     GC_wait_for_markers_init();
     GC_COND_LOG_PRINTF("Started %d mark helper threads\n", GC_markers_m1);


### PR DESCRIPTION
Thanks for merge #91 at 95947bdc584abab6def8c00d9edf6488c4dfcb1c.
I have some minor comments to this commit.

I add `GC_markers_m1 = i;` line before restoring sigmask at `pthread_support.c`  because of just a cosmetic reason.
But `GC_markers_m1 = i;` line in `win32_threads.c` is places after restoring sigmask.

You can move `GC_markers_m1 = i;` line to after restoring sigmask, and synchronize variable assignment semantics with `win32_threads.c`.