### PR TITLE
[Hurd] Use mmap instead of sbrk

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1552,6 +1552,10 @@
 #     define DATAEND ((ptr_t)(_end))
 /* #     define MPROTECT_VDB  Not quite working yet? */
 #     define DYNAMIC_LOADING
+#     ifndef USE_MMAP
+#       define USE_MMAP
+#     endif
+#     define USE_MMAP_ANON
 #   endif
 #   ifdef DARWIN
 #     define OS_TYPE "DARWIN"


### PR DESCRIPTION
As discussed by @sthibaul in <http://news.gmane.org/find-root.php?message_id=%3C20140831011051.GF19374%40type.youpi.perso.aquilenet.fr%3E>, and <http://news.gmane.org/find-root.php?message_id=%3C20140831152004.GA25911%40type.youpi.perso.aquilenet.fr%3E>, which I recently committed to GCC trunk.  I adjusted the patch to use the standard way of doing this in ` include/private/gcconfig.h `; will update GCC trunk once this gets accepted.

* include/private/gcconfig.h [I386 && HURD]: Define USE_MMAP, USE_MMAP_ANON.