### PR TITLE
Dump the block information in CSV format

### DIFF
--- a/reclaim.c
+++ b/reclaim.c
@@ -535,13 +535,14 @@ STATIC void GC_print_block_descr(struct hblk *h,
     size_t bytes = hhdr -> hb_sz;
     struct Print_stats *ps;
     unsigned n_marks = GC_n_set_marks(hhdr);
+    unsigned n_objects = HBLK_OBJS(bytes);
 
     if (hhdr -> hb_n_marks != n_marks) {
-      GC_printf("(%u:%u,%u!=%u)\n", hhdr->hb_obj_kind, (unsigned)bytes,
-                (unsigned)hhdr->hb_n_marks, n_marks);
+      GC_printf("%u,%u,%u!=%u,%u\n", hhdr->hb_obj_kind, (unsigned)bytes,
+                (unsigned)hhdr->hb_n_marks, n_marks, n_objects);
     } else {
-      GC_printf("(%u:%u,%u)\n", hhdr->hb_obj_kind,
-                (unsigned)bytes, n_marks);
+      GC_printf("%u,%u,%u,%u\n", hhdr->hb_obj_kind,
+                (unsigned)bytes, n_marks, n_objects);
     }
     bytes += HBLKSIZE-1;
     bytes &= ~(HBLKSIZE-1);
@@ -555,7 +556,7 @@ void GC_print_block_list(void)
 {
     struct Print_stats pstats;
 
-    GC_printf("(kind(0=ptrfree,1=normal,2=unc.):size_in_bytes, #_marks_set)\n");
+    GC_printf("kind(0=ptrfree,1=normal,2=unc.),size_in_bytes, #_marks_set , #objs\n");
     pstats.number_of_blocks = 0;
     pstats.total_bytes = 0;
     GC_apply_to_all_blocks(GC_print_block_descr, (word)&pstats);


### PR DESCRIPTION
Dump the block information in CSV format

This makes it easy to copy this information into a new file and process it
with tools that understand CSV, for example to create histograms of block
utilisation.

Thanks