### PR TITLE
check for execinfo.h directly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -473,6 +473,12 @@ case "$host" in
 esac
 AM_CONDITIONAL(AVOID_CPP_LIB,test $avoid_cpp_lib = yes)
 
+# Check for various headers.
+AC_CHECK_HEADERS([execinfo.h])
+if test "$ac_cv_header_execinfo_h" != "yes"; then
+  AC_DEFINE([GC_MISSING_EXECINFO_H], [1], [Missing execinfo.h header])
+fi
+
 # extra LD Flags which are required for targets
 case "${host}" in
   *-*-darwin*)

--- a/include/gc_config_macros.h
+++ b/include/gc_config_macros.h
@@ -287,7 +287,8 @@
 #   include <features.h>
 # endif
 # if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1 || __GLIBC__ > 2) \
-        && !defined(__ia64__) && !defined(__UCLIBC__) \
+        && !defined(__ia64__) \
+        && !defined(GC_MISSING_EXECINFO_H) \
         && !defined(GC_HAVE_BUILTIN_BACKTRACE)
 #   define GC_HAVE_BUILTIN_BACKTRACE
 # endif


### PR DESCRIPTION
The current header depends on glibc/uClibc version checks to determine
whether execinfo.h exists which breaks other C libs.  Instead, add an
explicit configure check for it.