### PR TITLE
spelling fixes

### DIFF
--- a/SMakefile.amiga
+++ b/SMakefile.amiga
@@ -1,6 +1,6 @@
 
 # Rewritten smakefile for amiga / sas/c. -Kjetil M.
-# Dont use the cord-package if you define parm=both or parm=reg.
+# Don't use the cord-package if you define parm=both or parm=reg.
 
 
 #----------------TOOLS--------------------------------

--- a/WCC_MAKEFILE
+++ b/WCC_MAKEFILE
@@ -1,7 +1,7 @@
 # Makefile for Watcom C/C++ 10.5, 10.6, 11.0 on NT, OS2 and DOS4GW.
 # May work with Watcom 10.0.
 
-# Uncoment one of the lines below for cross compilation.
+# Uncomment one of the lines below for cross compilation.
 SYSTEM=MSWIN32
 #SYSTEM=DOS4GW
 #SYSTEM=OS2

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,7 @@ else
         if test :$GCC: != :"yes": ; then
             gc_cflags="${gc_flags} +ESdbgasm"
         fi
-        # :TODO: actaully we should check using Autoconf if
+        # :TODO: actually we should check using Autoconf if
         #     the compiler supports this option.
         ;;
     esac
@@ -860,7 +860,7 @@ fi
 
 dnl This is something of a hack.  When cross-compiling we turn off
 dnl some functionality.  We also enable the "small" configuration.
-dnl These is only correct when targetting an embedded system.  FIXME.
+dnl These is only correct when targeting an embedded system.  FIXME.
 if test -n "${with_cross_host}"; then
    AC_DEFINE([NO_CLOCK], 1, [Define to not use system clock (cross compiling).])
    AC_DEFINE([SMALL_CONFIG], 1,

--- a/doc/README.amiga
+++ b/doc/README.amiga
@@ -48,7 +48,7 @@ WHATS NEW:
                  It is also the most important flag to set to prevent
                  GC from returning chip-mem. Beware that it slows down a lot
                  when a program is rapidly allocating/deallocating when
-                 theres either very little fast-memory left or verly little
+                 there's either very little fast-memory left or verly little
                  chip-memory left. Its not a very common situation, but gctest
                  sometimes (very rare) use many minutes because of this.
 
@@ -249,7 +249,7 @@ will not behave well with Amiga specific code. Especially not inter-
 process comms via messages, and setting up public structures like
 Intuition objects or anything else in the system lists. For the
 time being the use of this library is limited to single threaded
-ANSI/POSIX  compliant or near-complient code. (ie. Stick to stdio
+ANSI/POSIX  compliant or near-compliant code. (ie. Stick to stdio
 for now). Given this limitation there is currently no mechanism for
 allocating "CHIP" or "PUBLIC" memory under the garbage collector.
 I'll add this after giving it considerable thought. The major
@@ -260,7 +260,7 @@ If you allocate your own stack in client code, you will have to
 assign the pointer plus stack size to GC_stackbottom.
 
 The initial stack size of the target program can be compiled in by
-setting the __stack symbol (see SAS documentaion). It can be over-
+setting the __stack symbol (see SAS documentation). It can be over-
 ridden from the CLI by running the AmigaDOS "stack" program, or from
 the WorkBench by setting the stack size in the tool types window.
 

--- a/extra/AmigaOS.c
+++ b/extra/AmigaOS.c
@@ -221,11 +221,11 @@ void GC_amiga_free_all_mem(void){
         printf("GC_gcollect was called %d times to avoid returning NULL or start allocating with the MEMF_ANY flag.\n",numcollects);
         printf("%d of them was a success. (the others had to use allocation from the OS.)\n",nullretries);
         printf("\n");
-        printf("Succeded forcing %d gc-allocations (%d bytes) of chip-mem to be fast-mem.\n",succ,succ2);
+        printf("Succeeded forcing %d gc-allocations (%d bytes) of chip-mem to be fast-mem.\n",succ,succ2);
         printf("Failed forcing %d gc-allocations (%d bytes) of chip-mem to be fast-mem.\n",nsucc,nsucc2);
         printf("\n");
         printf(
-                "Number of retries before succeding a chip->fast force:\n"
+                "Number of retries before succeeding a chip->fast force:\n"
                 "0: %d, 1: %d, 2-9: %d, 10-49: %d, 50-149: %d, >150: %d\n",
                 cur0,cur1,cur10,cur50,cur150,cur151
         );

--- a/include/gc.h
+++ b/include/gc.h
@@ -642,7 +642,7 @@ GC_API GC_stop_func GC_CALL GC_get_stop_func(void);
 /* This getter remains lock-free (unsynchronized) for compatibility     */
 /* reason since some existing clients call it from a GC callback        */
 /* holding the allocator lock.  (This API function and the following    */
-/* four ones bellow were made thread-safe in GC v7.2alpha1 and          */
+/* four ones below were made thread-safe in GC v7.2alpha1 and          */
 /* reverted back in v7.2alpha7 for the reason described.)               */
 GC_API size_t GC_CALL GC_get_heap_size(void);
 

--- a/tools/setjmp_t.c
+++ b/tools/setjmp_t.c
@@ -112,7 +112,7 @@ int main(void)
     setjmp(b);
     if (y == 1) {
       if (x == 2) {
-        printf("Setjmp-based generic mark_regs code probably wont work.\n");
+        printf("Setjmp-based generic mark_regs code probably won't work.\n");
         printf("But we rarely try that anymore.  If you have getcontect()\n");
         printf("this probably doesn't matter.\n");
       } else if (x == 1) {


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.