### PR TITLE
#include <sys/time.h> to get timeval

### DIFF
--- a/pthread_stop_world.c
+++ b/pthread_stop_world.c
@@ -41,6 +41,7 @@
 
 #else /* !GC_OPENBSD_UTHREADS && !NACL */
 
+#include <sys/time.h>
 #include <signal.h>
 #include <semaphore.h>
 #include <errno.h>


### PR DESCRIPTION
On my mipsel-unknown-linux-gnu, I had to #include <sys/time.h> to get timeval.