### PR TITLE
docs are dist_doc_DATA

### DIFF
--- a/doc/doc.am
+++ b/doc/doc.am
@@ -12,7 +12,7 @@
 
 # installed documentation
 #
-dist_pkgdata_DATA = \
+dist_doc_DATA = \
         AUTHORS \
         README.md \
         doc/README.DGUX386 \


### PR DESCRIPTION
They should be installed to /usr/share/doc.

RE.
https://cygwin.com/ml/cygwin-apps/2017-05/msg00065.html
https://github.com/ivmai/libatomic_ops/pull/25