### PR TITLE
Fix uClibc build

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1442,7 +1442,7 @@
 #         define GC_PREFETCH_FOR_WRITE(x) \
             __asm__ __volatile__ ("prefetchw %0" : : "m"(*(char *)(x)))
 #       endif
-#       if defined(__GLIBC__)
+#       if defined(__GLIBC__) && !defined(__UCLIBC__)
           /* Workaround lock elision implementation for some glibc.     */
 #         define GLIBC_2_19_TSX_BUG
 #         include <gnu/libc-version.h> /* for gnu_get_libc_version() */
@@ -2455,7 +2455,7 @@
           /* FIXME: This seems to be fixed in GLibc v2.14.              */
 #         define GETCONTEXT_FPU_EXCMASK_BUG
 #       endif
-#       if defined(__GLIBC__)
+#       if defined(__GLIBC__) && !defined(__UCLIBC__)
           /* Workaround lock elision implementation for some glibc.     */
 #         define GLIBC_2_19_TSX_BUG
 #         include <gnu/libc-version.h> /* for gnu_get_libc_version() */


### PR DESCRIPTION
uClibc defines __GLIBC__ but does not contain libc-version.h leading to
a build error:

```
./include/private/gcconfig.h:1426:72: fatal error: gnu/libc-version.h: No such file or directory
 #         include <gnu/libc-version.h> /* for gnu_get_libc_version() */
```