### PR TITLE
Fix issues with using mmap on Cygwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -887,14 +887,6 @@ AC_ARG_ENABLE(munmap,
 if test x$enable_munmap != x -a x$enable_munmap != xno; then
     AC_DEFINE([USE_MMAP], 1,
               [Define to use mmap instead of sbrk to expand the heap.])
-    case "$host" in
-      *-*-cygwin*)
-        # Workaround for Cygwin: use VirtualAlloc since mmap(PROT_NONE) fails
-        AC_DEFINE([USE_WINALLOC], 1,
-                  [Define to use Win32 VirtualAlloc (instead of sbrk or
-                   mmap) to expand the heap.])
-        ;;
-    esac
     AC_DEFINE([USE_MUNMAP], 1,
               [Define to return memory to OS with munmap calls
                (see doc/README.macros).])


### PR DESCRIPTION
This fixes two issues that prevented using mmap for allocations/unmap on Cygwin:

* Calling `mmap` with new protection flags on an existing map with `MAP_FIXED` is broken on Cygwin.  This was discussed a little bit here, and is the main source of problems: http://cygwin.1069669.n5.nabble.com/mmap-MAP-FIXED-vs-mprotect-td98125.html  However, calling `mprotect()` on the given address range with `PROT_NONE` seems to work fine.
* A more subtle issue, but one that needs to be resolved for the first issue to be fixed properly, is that allocations made with `mmap` are aligned to the allocation granularity, which (at least on 64-bit Windows) is *not* the same a the page size.  Therefore attempts to align an address to the start of the memory map it's in will fail unless `GC_page_size` is actually set to `SYSTEM_INFO.dwAllocationGranularity`.  I considered adding a separate variable to distinguish this from the actual page size, but in practice there's no good reason to make allocations smaller than `dwAllocationGranularity` so I just use it instead of the actual page size here (as Cygwin itself does in many cases).

With those two issues fixed we can remove the forced use of `USE_WINALLOC`  from Cygwin, which was undesirable to begin with due to its incompatibility with `HANDLE_FORK`.

https://trac.sagemath.org/ticket/23973#comment:16 has more background.