### PR TITLE
Fix marking of disclaim-reachable objects in incremental mode.

### DIFF
--- a/mark.c
+++ b/mark.c
@@ -2015,7 +2015,13 @@ STATIC struct hblk * GC_push_next_marked(struct hblk *h)
         h += OBJ_SZ_TO_BLOCKS(hhdr -> hb_sz);
         hhdr = HDR(h);
     }
-    GC_push_marked(h, hhdr);
+#   ifdef ENABLE_DISCLAIM
+      if ((hhdr -> hb_flags & MARK_UNCONDITIONALLY) != 0) {
+        GC_push_unconditionally(h, hhdr);
+      } else
+#   endif
+    /* else */
+        GC_push_marked(h, hhdr);
     return(h + OBJ_SZ_TO_BLOCKS(hhdr -> hb_sz));
   }
 #endif /* !GC_DISABLE_INCREMENTAL */


### PR DESCRIPTION
* mark.c [ENABLE_DISCLAIM] (GC_push_next_marked_dirty): Honour
MARK_UNCONDITIONALLY when rescanning dirty blocks during incremental
marking.

## Comment

My understanding of the collector is a rusty, but I'm quite confident this fixes #192.  Unconditional marking is done analogously to marking from uncollectable blocks, since they are meant to secure access to data for disclaim notifiers after the data is no longer marked.  Then we may ask, why not also add the `MARK_UNCONDITIONALLY` case to `GC_push_next_marked`, which is also applied to uncollectable blocks?  But it seems to me that this function does not need to scan uncollectable (and unconditionally marked) blocks since those are already handled in the `MS_PUSH_UNCOLLECTABLE` phase.
