### PR TITLE
Extern "C" around declarations, not includes.

### DIFF
--- a/include/gc_inline.h
+++ b/include/gc_inline.h
@@ -47,6 +47,10 @@
 # endif
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef GC_PREFETCH_FOR_WRITE
 # if GC_GNUC_PREREQ(3, 0) && !defined(GC_NO_PREFETCH_FOR_WRITE)
 #   define GC_PREFETCH_FOR_WRITE(x) __builtin_prefetch((x), 1)
@@ -181,5 +185,9 @@ GC_API GC_ATTR_MALLOC GC_ATTR_ALLOC_SIZE(1) void * GC_CALL
 
 GC_API void GC_CALL GC_print_free_list(int /* kind */,
                                        size_t /* sz_in_granules */);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* !GC_INLINE_H */

--- a/include/private/darwin_semaphore.h
+++ b/include/private/darwin_semaphore.h
@@ -18,6 +18,10 @@
 #ifndef GC_DARWIN_SEMAPHORE_H
 #define GC_DARWIN_SEMAPHORE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if !defined(GC_DARWIN_THREADS)
 # error darwin_semaphore.h included with GC_DARWIN_THREADS not defined
 #endif
@@ -76,5 +80,9 @@ GC_INLINE int sem_destroy(sem_t *sem) {
     return pthread_cond_destroy(&sem->cond) != 0
            || pthread_mutex_destroy(&sem->mutex) != 0 ? -1 : 0;
 }
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif

--- a/include/private/darwin_stop_world.h
+++ b/include/private/darwin_stop_world.h
@@ -25,6 +25,10 @@
 #include <mach/mach.h>
 #include <mach/thread_act.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct thread_stop_info {
   mach_port_t mach_thread;
   ptr_t stack_ptr; /* Valid only when thread is in a "blocked" state.   */
@@ -41,6 +45,10 @@ struct thread_stop_info {
 
 #if defined(PARALLEL_MARK) && !defined(GC_NO_THREADS_DISCOVERY)
   GC_INNER GC_bool GC_is_mach_marker(thread_act_t);
+#endif
+
+#ifdef __cplusplus
+} /* extern "C" */
 #endif
 
 #endif

--- a/include/private/dbg_mlc.h
+++ b/include/private/dbg_mlc.h
@@ -30,6 +30,10 @@
 # include "gc_backptr.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if CPP_WORDSZ == 32
 # define START_FLAG (word)0xfedcedcb
 # define END_FLAG (word)0xbcdecdef
@@ -165,6 +169,10 @@ typedef struct {
         ((*((word *)p) & 1) && GC_has_other_debug_info(p) > 0)
 #else
 # define GC_HAS_DEBUG_INFO(p) (GC_has_other_debug_info(p) > 0)
+#endif
+
+#ifdef __cplusplus
+} /* extern "C" */
 #endif
 
 #endif /* _DBG_MLC_H */

--- a/include/private/gc_atomic_ops.h
+++ b/include/private/gc_atomic_ops.h
@@ -23,6 +23,11 @@
 #ifdef GC_BUILTIN_ATOMIC
 
 # include "gc.h" /* for GC_word */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
   typedef GC_word AO_t;
 
 # ifdef GC_PRIVATE_H /* have GC_INLINE */
@@ -82,6 +87,10 @@
     }
 #   define AO_HAVE_compare_and_swap_release
 # endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #else
   /* Fallback to libatomic_ops. */

--- a/include/private/gc_hdrs.h
+++ b/include/private/gc_hdrs.h
@@ -15,6 +15,10 @@
 #ifndef GC_HEADERS_H
 #define GC_HEADERS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct hblkhdr hdr;
 
 #if CPP_WORDSZ != 32 && CPP_WORDSZ < 36
@@ -207,5 +211,9 @@ typedef struct bi {
 /* Get an HBLKSIZE aligned address closer to the beginning of the block */
 /* h.  Assumes hhdr == HDR(h) and IS_FORWARDING_ADDR(hhdr).             */
 #define FORWARDED_ADDR(h, hhdr) ((struct hblk *)(h) - (size_t)(hhdr))
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* GC_HEADERS_H */

--- a/include/private/gc_locks.h
+++ b/include/private/gc_locks.h
@@ -18,6 +18,10 @@
 #ifndef GC_LOCKS_H
 #define GC_LOCKS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Mutual exclusion between allocator/collector routines.
  * Needed if there is more than one allocator thread.
@@ -30,12 +34,32 @@
 
 #  if defined(GC_PTHREADS) && !defined(GC_WIN32_THREADS) \
       && !defined(SN_TARGET_ORBIS) && !defined(SN_TARGET_PSP2)
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #    include "gc_atomic_ops.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #  endif
 
 #  ifdef PCR
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #    include <base/PCR_Base.h>
 #    include <th/PCR_Th.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
      GC_EXTERN PCR_Th_ML GC_allocate_ml;
 #    if defined(CPPCHECK)
 #      define DCL_LOCK_STATE /* empty */
@@ -59,7 +83,17 @@
 #      define WIN32_LEAN_AND_MEAN 1
 #    endif
 #    define NOSERVICE
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #    include <windows.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #    define NO_THREAD (DWORD)(-1)
      GC_EXTERN CRITICAL_SECTION GC_allocate_ml;
 #    ifdef GC_ASSERTIONS
@@ -86,7 +120,16 @@
 #      define UNCOND_UNLOCK() LeaveCriticalSection(&GC_allocate_ml)
 #    endif /* !GC_ASSERTIONS */
 #  elif defined(GC_PTHREADS)
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #    include <pthread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
      /* Posix allows pthread_t to be a struct, though it rarely is.     */
      /* Unfortunately, we need to use a pthread_t to index a data       */
@@ -123,7 +166,17 @@
                 /* != NUMERIC_THREAD_ID(pthread_self()) for any thread */
 
 #    ifdef SN_TARGET_PSP2
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #      include "psp2-support.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
        GC_EXTERN WapiMutex GC_allocate_ml_PSP2;
 #      define UNCOND_LOCK() { int res; GC_ASSERT(I_DONT_HOLD_LOCK()); \
                               res = PSP2_MutexLock(&GC_allocate_ml_PSP2); \
@@ -167,7 +220,17 @@
 #      endif
 #    endif /* THREAD_LOCAL_ALLOC || USE_PTHREAD_LOCKS */
 #    ifdef USE_PTHREAD_LOCKS
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #      include <pthread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
        GC_EXTERN pthread_mutex_t GC_allocate_ml;
 #      ifdef GC_ASSERTIONS
 #        define UNCOND_LOCK() { GC_ASSERT(I_DONT_HOLD_LOCK()); \
@@ -267,5 +330,9 @@
 # ifndef DCL_LOCK_STATE
 #   define DCL_LOCK_STATE
 # endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* GC_LOCKS_H */

--- a/include/private/gc_pmark.h
+++ b/include/private/gc_pmark.h
@@ -48,6 +48,10 @@
 # include "gc_priv.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The real declarations of the following is in gc_priv.h, so that      */
 /* we can avoid scanning the following table.                           */
 /*
@@ -477,5 +481,9 @@ typedef int mark_state_t;       /* Current state of marking, as follows:*/
 #define MS_INVALID 5            /* "I" may not hold.                    */
 
 GC_EXTERN mark_state_t GC_mark_state;
+
+#ifdef __cplusplus
+} /* extern "C" { */
+#endif
 
 #endif  /* GC_PMARK_H */

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -313,6 +313,12 @@ typedef char * ptr_t;   /* A generic pointer to which we can add        */
                     /* This is now really controlled at startup,        */
                     /* through GC_all_interior_pointers.                */
 
+/* Note: Only wrap our own declarations, and not other people's headers.
+ * i.e. never put extern "C" around an #include
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef GC_NO_FINALIZATION
 # define GC_INVOKE_FINALIZERS() GC_notify_or_invoke_finalizers()
@@ -429,8 +435,18 @@ typedef char * ptr_t;   /* A generic pointer to which we can add        */
 #   define WIN32_LEAN_AND_MEAN 1
 # endif
 # define NOSERVICE
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 # include <windows.h>
 # include <winbase.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 # define CLOCK_TYPE DWORD
 # define GET_TIME(x) (void)(x = GetTickCount())
 # define MS_TIME_DIFF(a,b) ((long)((a)-(b)))
@@ -441,11 +457,21 @@ typedef char * ptr_t;   /* A generic pointer to which we can add        */
 # define GET_TIME(x) (void)(x = n3ds_get_system_tick())
 # define MS_TIME_DIFF(a,b) ((long)n3ds_convert_tick_to_ms((a)-(b)))
 #else /* !BSD_TIME && !NN_PLATFORM_CTR && !MSWIN32 && !MSWINCE */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 # include <time.h>
 # if defined(FREEBSD) && !defined(CLOCKS_PER_SEC)
 #   include <machine/limits.h>
 #   define CLOCKS_PER_SEC CLK_TCK
 # endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 # if !defined(CLOCKS_PER_SEC)
 #   define CLOCKS_PER_SEC 1000000
     /* This is technically a bug in the implementation.                 */
@@ -481,14 +507,21 @@ typedef char * ptr_t;   /* A generic pointer to which we can add        */
 # if defined(VAX)
 #   define BCOPY_EXISTS
 # endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 # if defined(AMIGA)
 #   include <string.h>
 #   define BCOPY_EXISTS
 # endif
+
 # if defined(DARWIN)
 #   include <string.h>
 #   define BCOPY_EXISTS
 # endif
+
 # if defined(MACOS) && defined(POWERPC)
 #   include <MacMemory.h>
 #   define bcopy(x,y,n) BlockMoveData(x, y, n)
@@ -505,11 +538,25 @@ typedef char * ptr_t;   /* A generic pointer to which we can add        */
 #   define BZERO(x,n) bzero((void *)(x),(size_t)(n))
 # endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Stop and restart mutator threads.
  */
 # ifdef PCR
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #     include "th/PCR_ThCtl.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #     define STOP_WORLD() \
         PCR_ThCtl_SetExclusiveMode(PCR_ThCtl_ExclusiveMode_stopNormal, \
                                    PCR_allSigsBlocked, \
@@ -649,11 +696,21 @@ GC_EXTERN GC_warn_proc GC_current_warn_proc;
 #endif
 
 #if defined(DARWIN)
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 # include <mach/thread_status.h>
 # ifndef MAC_OS_X_VERSION_MAX_ALLOWED
 #   include <AvailabilityMacros.h>
                 /* Include this header just to import the above macro.  */
 # endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 # if defined(POWERPC)
 #   if CPP_WORDSZ == 32
 #     define GC_THREAD_STATE_T          ppc_thread_state_t
@@ -760,7 +817,17 @@ GC_EXTERN GC_warn_proc GC_current_warn_proc;
 /* separate free lists for each multiple of GRANULE_BYTES       */
 /* up to (TINY_FREELISTS-1) * GRANULE_BYTES.  After that they   */
 /* may be spread out further.                                   */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #include "../gc_tiny_fl.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define GRANULE_BYTES GC_GRANULE_BYTES
 #define TINY_FREELISTS GC_TINY_FREELISTS
 
@@ -977,13 +1044,33 @@ typedef word page_hash_table[PHT_SIZE];
            /* to allocate smaller header for large objects.  */
 
 #ifdef PARALLEL_MARK
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 # include "gc_atomic_ops.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 # define counter_t volatile AO_t
 #else
   typedef size_t counter_t;
 # if defined(THREADS) && (defined(MPROTECT_VDB) || defined(THREAD_SANITIZER) \
                 || (defined(GC_ASSERTIONS) && defined(THREAD_LOCAL_ALLOC)))
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #   include "gc_atomic_ops.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 # endif
 #endif /* !PARALLEL_MARK */
 
@@ -2559,7 +2646,15 @@ GC_INNER ptr_t GC_store_debug_info(ptr_t p, word sz, const char *str,
 # define GC_SEM_INIT_PSHARED 0
 #endif
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #include <setjmp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Some macros for setjmp that works across signal handlers     */
 /* were possible, and a couple of routines to facilitate        */
@@ -2568,7 +2663,17 @@ GC_INNER ptr_t GC_store_debug_info(ptr_t p, word sz, const char *str,
 #if (defined(UNIX_LIKE) || (defined(NEED_FIND_LIMIT) && defined(CYGWIN32))) \
     && !defined(GC_NO_SIGSETJMP)
 # if defined(SUNOS5SIGS) && !defined(FREEBSD) && !defined(LINUX)
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #  include <sys/siginfo.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 # endif
   /* Define SETJMP and friends to be the version that restores  */
   /* the signal mask.                                           */
@@ -2601,7 +2706,17 @@ GC_INNER ptr_t GC_store_debug_info(ptr_t p, word sz, const char *str,
 #endif
 
 #if defined(DATASTART_USES_BSDGETDATASTART)
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 # include <machine/trap.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 # if !defined(PCR)
 #   define NEED_FIND_LIMIT
 # endif
@@ -2659,5 +2774,9 @@ GC_INNER ptr_t GC_store_debug_info(ptr_t p, word sz, const char *str,
 # define RESTORE_CANCEL(state) (void)0
 # define ASSERT_CANCEL_DISABLED() (void)0
 #endif /* !CANCEL_SAFE */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* GC_PRIVATE_H */

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -32,6 +32,14 @@
 #   include <stddef.h>  /* For size_t etc. */
 # endif
 
+/* Note: Only wrap our own declarations, and not other people's headers.
+ * In this case, wrap our entire file, but temporarily unwrap/rewrap
+ * around #includes. Types and macros do not need such wrapping, only data and functions.
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Convenient internal macro to test version of Clang.  */
 #if defined(__clang__) && defined(__clang_major__)
 # define GC_CLANG_PREREQ(major, minor) \
@@ -117,7 +125,17 @@
 /* And one for Darwin: */
 # if defined(macosx) || (defined(__APPLE__) && defined(__MACH__))
 #   define DARWIN
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #   include <TargetConditionals.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 # endif
 
 /* Determine the machine type: */
@@ -263,7 +281,17 @@
 # if (defined(sun) || defined(__sun)) && (defined(sparc) || defined(__sparc))
 #   define SPARC
     /* Test for SunOS 5.x */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #   include <errno.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #   define SOLARIS
 #   define mach_type_known
 # elif defined(sparc) && defined(unix) && !defined(sun) && !defined(linux) \
@@ -897,7 +925,17 @@
 #       define MPROTECT_VDB
 #       ifdef __ELF__
 #            define DYNAMIC_LOADING
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #            include <features.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #            if defined(__GLIBC__) && __GLIBC__ >= 2
 #              define SEARCH_FOR_DATA_START
 #            else /* !GLIBC2 */
@@ -928,7 +966,17 @@
 #   endif
 #   ifdef MACOS
 #     ifndef __LOWMEM__
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #     include <LowMem.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #     endif
 #     define OS_TYPE "MACOS"
                 /* see os_dep.c for details of global data segments. */
@@ -950,7 +998,17 @@
 #   ifdef MACOS
 #     define ALIGNMENT 2  /* Still necessary?  Could it be 4?   */
 #     ifndef __LOWMEM__
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #     include <LowMem.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #     endif
 #     define OS_TYPE "MACOS"
                         /* see os_dep.c for details of global data segments. */
@@ -1004,7 +1062,17 @@
 #     define DATAEND   ((ptr_t)get_end())
 #     define USE_MMAP_ANON
 #     define MPROTECT_VDB
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #     include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #     define GETPAGESIZE() (unsigned)getpagesize()
 #     if defined(USE_PPC_PREFETCH) && defined(__GNUC__)
         /* The performance impact of prefetches is untested */
@@ -1021,8 +1089,18 @@
 #     define OS_TYPE "OPENBSD"
 #     define ALIGNMENT 4
 #     ifndef GC_OPENBSD_THREADS
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <sys/param.h>
 #       include <uvm/uvm_extern.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
         /* USRSTACK is defined in <machine/vmparam.h> but that is       */
         /* protected by _KERNEL in <uvm/uvm_param.h> file.              */
 #       ifdef USRSTACK
@@ -1198,14 +1276,34 @@
 /*      Apparently USRSTACK is defined to be USERLIMIT, but in some     */
 /*      installations that's undefined.  We work around this with a     */
 /*      gross hack:                                                     */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <sys/vmparam.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       ifdef USERLIMIT
           /* This should work everywhere, but doesn't.  */
 #         define STACKBOTTOM ((ptr_t)USRSTACK)
 #       else
 #         define HEURISTIC2
 #       endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       define GETPAGESIZE() (unsigned)sysconf(_SC_PAGESIZE)
                 /* getpagesize() appeared to be missing from at least one */
                 /* Solaris 5.4 installation.  Weird.                      */
@@ -1244,8 +1342,18 @@
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
 #     ifndef GC_OPENBSD_THREADS
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <sys/param.h>
 #       include <uvm/uvm_extern.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       ifdef USRSTACK
 #         define STACKBOTTOM ((ptr_t)USRSTACK)
 #       else
@@ -1311,7 +1419,17 @@
 #   endif
 #   ifdef HAIKU
 #     define OS_TYPE "HAIKU"
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #     include <OS.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #     define GETPAGESIZE() (unsigned)B_PAGE_SIZE
       extern int etext[];
 #     define DATASTART ((ptr_t)((((word)(etext)) + 0xfff) & ~0xfff))
@@ -1333,7 +1451,17 @@
 /*      Apparently USRSTACK is defined to be USERLIMIT, but in some     */
 /*      installations that's undefined.  We work around this with a     */
 /*      gross hack:                                                     */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <sys/vmparam.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       ifdef USERLIMIT
           /* This should work everywhere, but doesn't.  */
 #         define STACKBOTTOM ((ptr_t)USRSTACK)
@@ -1386,7 +1514,17 @@
 #       define DATAEND ((ptr_t)(&_end))
 #       define STACK_GROWS_DOWN
 #       define HEURISTIC2
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       define GETPAGESIZE() (unsigned)sysconf(_SC_PAGESIZE)
 #       define DYNAMIC_LOADING
 #       ifndef USE_MMAP
@@ -1410,7 +1548,17 @@
                 /* thus allowing the heap to grow to ~3GB               */
 #       ifdef __ELF__
 #            define DYNAMIC_LOADING
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #            include <features.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #            if defined(__GLIBC__) && __GLIBC__ >= 2 \
                 || defined(HOST_ANDROID) || defined(HOST_TIZEN)
 #                define SEARCH_FOR_DATA_START
@@ -1466,7 +1614,17 @@
 #       if defined(__GLIBC__) && !defined(__UCLIBC__)
           /* Workaround lock elision implementation for some glibc.     */
 #         define GLIBC_2_19_TSX_BUG
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #         include <gnu/libc-version.h> /* for gnu_get_libc_version() */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       endif
 #   endif
 #   ifdef CYGWIN32
@@ -1501,7 +1659,17 @@
 #   endif
 #   ifdef DJGPP
 #       define OS_TYPE "DJGPP"
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include "stubinfo.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
         extern int etext[];
         extern int _stklen;
         extern int __djgpp_stack_limit;
@@ -1513,8 +1681,18 @@
 #   ifdef OPENBSD
 #       define OS_TYPE "OPENBSD"
 #       ifndef GC_OPENBSD_THREADS
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #         include <sys/param.h>
 #         include <uvm/uvm_extern.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #         ifdef USRSTACK
 #           define STACKBOTTOM ((ptr_t)USRSTACK)
 #         else
@@ -1576,7 +1754,17 @@
 #   endif
 #   ifdef RTEMS
 #       define OS_TYPE "RTEMS"
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <sys/unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
         extern int etext[];
         extern int end[];
         void *rtems_get_stack_bottom(void);
@@ -1628,7 +1816,17 @@
 #     define STACKBOTTOM ((ptr_t)0xc0000000)
 #     define USE_MMAP_ANON
 #     define MPROTECT_VDB
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #     include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #     define GETPAGESIZE() (unsigned)getpagesize()
       /* There seems to be some issues with trylock hanging on darwin.  */
       /* This should be looked into some more.                          */
@@ -1756,8 +1954,18 @@
 #     define OS_TYPE "OPENBSD"
 #     define ALIGNMENT 4
 #     ifndef GC_OPENBSD_THREADS
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <sys/param.h>
 #       include <uvm/uvm_extern.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       ifdef USRSTACK
 #         define STACKBOTTOM ((ptr_t)USRSTACK)
 #       else
@@ -1868,7 +2076,17 @@
 #       define STACKBOTTOM ((ptr_t)environ)
 #     endif
 #     define DYNAMIC_LOADING
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #     include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+
+#endif
 #     define GETPAGESIZE() (unsigned)sysconf(_SC_PAGE_SIZE)
 #     ifndef __GNUC__
 #       define PREFETCH(x)  do { \
@@ -1888,8 +2106,18 @@
 #  ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
 #     ifndef GC_OPENBSD_THREADS
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <sys/param.h>
 #       include <uvm/uvm_extern.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       ifdef USRSTACK
 #         define STACKBOTTOM ((ptr_t)USRSTACK)
 #       else
@@ -1922,8 +2150,18 @@
 #       define OS_TYPE "OPENBSD"
 #       define ELF_CLASS ELFCLASS64
 #       ifndef GC_OPENBSD_THREADS
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #         include <sys/param.h>
 #         include <uvm/uvm_extern.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #         ifdef USRSTACK
 #           define STACKBOTTOM ((ptr_t)USRSTACK)
 #         else
@@ -2024,7 +2262,17 @@
 #       define STACKBOTTOM ((ptr_t)environ)
 #       define HPUX_STACKBOTTOM
 #       define DYNAMIC_LOADING
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       define GETPAGESIZE() (unsigned)sysconf(_SC_PAGE_SIZE)
         /* The following was empirically determined, and is probably    */
         /* not very robust.                                             */
@@ -2069,7 +2317,17 @@
 #           define CLEAR_DOUBLE(x) \
               __asm__ ("        stf.spill       [%0]=f0": : "r"((void *)(x)))
 #         else
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #           include <ia64intrin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #           define PREFETCH(x) __lfetch(__lfhint_none, (x))
 #           define GC_PREFETCH_FOR_WRITE(x) __lfetch(__lfhint_nta, (x))
 #           define CLEAR_DOUBLE(x) __stf_spill((void *)(x), 0)
@@ -2196,7 +2454,17 @@
 #     define STACKBOTTOM ((ptr_t)0x16fdfffff)
 #     define USE_MMAP_ANON
 #     define MPROTECT_VDB
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #     include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #     define GETPAGESIZE() (unsigned)getpagesize()
       /* FIXME: There seems to be some issues with trylock hanging on   */
       /* darwin. This should be looked into some more.                  */
@@ -2254,7 +2522,17 @@
 #       define STACK_GRAN 0x10000000
 #       ifdef __ELF__
 #            define DYNAMIC_LOADING
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #            include <features.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #            if defined(__GLIBC__) && __GLIBC__ >= 2 \
                 || defined(HOST_ANDROID) || defined(HOST_TIZEN)
 #                define SEARCH_FOR_DATA_START
@@ -2309,7 +2587,17 @@
 #     define STACKBOTTOM ((ptr_t)0x30000000)
 #     define USE_MMAP_ANON
 #     define MPROTECT_VDB
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #     include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #     define GETPAGESIZE() (unsigned)getpagesize()
       /* FIXME: There seems to be some issues with trylock hanging on   */
       /* darwin. This should be looked into some more.                  */
@@ -2321,8 +2609,18 @@
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
 #     ifndef GC_OPENBSD_THREADS
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <sys/param.h>
 #       include <uvm/uvm_extern.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       ifdef USRSTACK
 #         define STACKBOTTOM ((ptr_t)USRSTACK)
 #       else
@@ -2405,8 +2703,18 @@
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
 #     ifndef GC_OPENBSD_THREADS
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <sys/param.h>
 #       include <uvm/uvm_extern.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       ifdef USRSTACK
 #         define STACKBOTTOM ((ptr_t)USRSTACK)
 #       else
@@ -2474,7 +2782,17 @@
 #   ifdef SN_TARGET_ORBIS
 #     define DATASTART (ptr_t)ALIGNMENT
 #     define DATAEND (ptr_t)ALIGNMENT
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #     include <pthread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
       void *ps4_get_stack_bottom(void);
 #     define STACKBOTTOM ((ptr_t)ps4_get_stack_bottom())
 #   endif
@@ -2482,8 +2800,18 @@
 #       define OS_TYPE "OPENBSD"
 #       define ELF_CLASS ELFCLASS64
 #       ifndef GC_OPENBSD_THREADS
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #         include <sys/param.h>
 #         include <uvm/uvm_extern.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #         ifdef USRSTACK
 #           define STACKBOTTOM ((ptr_t)USRSTACK)
 #         else
@@ -2508,7 +2836,17 @@
 #       endif
 #       ifdef __ELF__
 #            define DYNAMIC_LOADING
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #            include <features.h>
+#ifdef __cplusplus
+
+extern "C" {
+#endif
+
 #            define SEARCH_FOR_DATA_START
              extern int _end[];
 #            define DATAEND ((ptr_t)(_end))
@@ -2526,7 +2864,17 @@
 #       if defined(__GLIBC__) && !defined(__UCLIBC__)
           /* Workaround lock elision implementation for some glibc.     */
 #         define GLIBC_2_19_TSX_BUG
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #         include <gnu/libc-version.h> /* for gnu_get_libc_version() */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       endif
 #   endif
 #   ifdef DARWIN
@@ -2542,7 +2890,17 @@
 #     define STACKBOTTOM ((ptr_t)0x7fff5fc00000)
 #     define USE_MMAP_ANON
 #     define MPROTECT_VDB
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #     include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #     define GETPAGESIZE() (unsigned)getpagesize()
       /* There seems to be some issues with trylock hanging on darwin.  */
       /* This should be looked into some more.                          */
@@ -2588,7 +2946,17 @@
 #   endif
 #   ifdef HAIKU
 #     define OS_TYPE "HAIKU"
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #     include <OS.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #     define GETPAGESIZE() (unsigned)B_PAGE_SIZE
       extern int etext[];
 #     define DATASTART ((ptr_t)((((word)etext) + 0xfff) & ~0xfff))
@@ -2611,7 +2979,17 @@
 /*      Apparently USRSTACK is defined to be USERLIMIT, but in some     */
 /*      installations that's undefined.  We work around this with a     */
 /*      gross hack:                                                     */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #       include <sys/vmparam.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #       ifdef USERLIMIT
           /* This should work everywhere, but doesn't.  */
 #         define STACKBOTTOM ((ptr_t)USRSTACK)
@@ -2684,7 +3062,17 @@
 #       define MPROTECT_VDB
 #       ifdef __ELF__
 #            define DYNAMIC_LOADING
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #            include <features.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #            if defined(__GLIBC__) && __GLIBC__ >= 2
 #                define SEARCH_FOR_DATA_START
 #            else
@@ -2811,14 +3199,34 @@
 
 #if (defined(SVR4) || defined(HOST_ANDROID) || defined(HOST_TIZEN)) \
     && !defined(GETPAGESIZE)
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 # include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 # define GETPAGESIZE() (unsigned)sysconf(_SC_PAGESIZE)
 #endif
 
 #ifndef GETPAGESIZE
 # if defined(SOLARIS) || defined(IRIX5) || defined(LINUX) \
      || defined(NETBSD) || defined(FREEBSD) || defined(HPUX)
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #   include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 # endif
 # define GETPAGESIZE() (unsigned)getpagesize()
 #endif
@@ -2875,7 +3283,17 @@
 #endif
 
 #ifdef GC_OPENBSD_THREADS
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 # include <sys/param.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
   /* Prior to 5.2 release, OpenBSD had user threads and required        */
   /* special handling.                                                  */
 # if OpenBSD < 201211
@@ -3455,5 +3873,9 @@
 #   define GET_MEM(bytes) (struct hblk *)GC_unix_get_mem(bytes)
 # endif
 #endif /* GC_PRIVATE_H */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* GCCONFIG_H */

--- a/include/private/msvc_dbg.h
+++ b/include/private/msvc_dbg.h
@@ -24,6 +24,9 @@
 
 #include <stdlib.h>
 
+/* Note: Only wrap our own declarations, and not other people's headers.
+ * i.e. never put extern "C" around an #include
+ */
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/private/pthread_stop_world.h
+++ b/include/private/pthread_stop_world.h
@@ -18,6 +18,13 @@
 #ifndef GC_PTHREAD_STOP_WORLD_H
 #define GC_PTHREAD_STOP_WORLD_H
 
+/* Note: Only wrap our own declarations, and not other people's headers.
+ * i.e. never put extern "C" around an #include
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct thread_stop_info {
 #   if !defined(GC_OPENBSD_UTHREADS) && !defined(NACL)
       volatile AO_t last_stop_count;
@@ -45,5 +52,9 @@ struct thread_stop_info {
 };
 
 GC_INNER void GC_stop_init(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif

--- a/include/private/pthread_support.h
+++ b/include/private/pthread_support.h
@@ -36,6 +36,13 @@
 # include "dbg_mlc.h" /* for oh type */
 #endif
 
+/* Note: Only wrap our own declarations, and not other people's headers.
+ * i.e. never put extern "C" around an #include
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* We use the allocation lock to protect thread-related data structures. */
 
 /* The set of all known threads.  We intercept thread creation and      */
@@ -175,6 +182,10 @@ GC_INNER_PTHRSTART GC_thread GC_start_rtn_prepare_thread(
                                         void **pstart_arg,
                                         struct GC_stack_base *sb, void *arg);
 GC_INNER_PTHRSTART void GC_thread_exit_proc(void *);
+
+#ifdef __cplusplus
+} /* extern C */
+#endif
 
 #endif /* GC_PTHREADS && !GC_WIN32_THREADS */
 

--- a/include/private/specific.h
+++ b/include/private/specific.h
@@ -16,6 +16,13 @@
 
 #include "gc_atomic_ops.h"
 
+/* Note: Only wrap our own declarations, and not other people's headers.
+ * i.e. never put extern "C" around an #include
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Called during key creation or setspecific.           */
 /* For the GC we already hold lock.                     */
 /* Currently allocated objects leak on thread exit.     */
@@ -32,7 +39,7 @@
 
 /* An entry describing a thread-specific value for a given thread.      */
 /* All such accessible structures preserve the invariant that if either */
-/* thread is a valid pthread id or qtid is a valid "quick tread id"     */
+/* thread is a valid pthread id or qtid is a valid "quick thread id"     */
 /* for a thread, then value holds the corresponding thread specific     */
 /* value.  This invariant must be preserved at ALL times, since         */
 /* asynchronous reads are allowed.                                      */
@@ -99,3 +106,7 @@ GC_INLINE void * GC_getspecific(tsd * key)
     }
     return GC_slow_getspecific(key, qtid, entry_ptr);
 }
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/include/private/thread_local_alloc.h
+++ b/include/private/thread_local_alloc.h
@@ -94,6 +94,7 @@ typedef struct thread_local_freelists {
         /* Value used for gcj_freelists[-1]; allocation is      */
         /* erroneous.                                           */
 # endif
+
   /* Free lists contain either a pointer or a small count       */
   /* reflecting the number of granules allocated at that        */
   /* size.                                                      */
@@ -152,6 +153,13 @@ typedef struct thread_local_freelists {
 # error implement me
 #endif
 
+/* Note: Only wrap our own declarations, and not other people's headers.
+ * i.e. never put extern "C" around an #include
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Each thread structure must be initialized.   */
 /* This call must be made from the new thread.  */
 /* Caller holds allocation lock.                */
@@ -181,6 +189,10 @@ extern
 /* This is set up by the thread_local_alloc implementation.  No need    */
 /* for cleanup on thread exit.  But the thread support layer makes sure */
 /* that GC_thread_key is traced, if necessary.                          */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* THREAD_LOCAL_ALLOC */
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,25 @@
 # modified is included with the above copyright notice.
 ##
 
+SET_SOURCE_FILES_PROPERTIES(
+	disclaim_bench.c
+	disclaim_test.c
+	huge_test.c
+	initsecondarythread.c
+	leak_test.c
+	middle.c
+	realloc_test.c
+	smash_test.c
+	staticrootslib.c
+	staticrootstest.c
+	subthread_create.c
+	test.c
+	test_atomic_ops.c
+	thread_leak_test.c
+	threadkey_test.c
+	trace_test.c
+	PROPERTIES LANGUAGE CXX)
+
 ADD_DEFINITIONS(-DGC_NOT_DLL)
 
 ADD_EXECUTABLE(gctest WIN32 test.c)

--- a/tests/leak_test.c
+++ b/tests/leak_test.c
@@ -9,14 +9,14 @@ int main(void) {
     GC_INIT();  /* Needed if thread-local allocation is enabled.        */
                 /* FIXME: This is not ideal.                            */
     for (i = 0; i < 10; ++i) {
-        p[i] = malloc(sizeof(int)+i);
+        p[i] = (int*)malloc(sizeof(int)+i);
     }
     CHECK_LEAKS();
     for (i = 1; i < 10; ++i) {
         free(p[i]);
     }
     for (i = 0; i < 9; ++i) {
-        p[i] = malloc(sizeof(int)+i);
+        p[i] = (int*)malloc(sizeof(int)+i);
     }
     CHECK_LEAKS();
     CHECK_LEAKS();

--- a/tests/realloc_test.c
+++ b/tests/realloc_test.c
@@ -12,15 +12,15 @@ int main(void) {
   GC_INIT();
 
   for (i = 0; i < COUNT; i++) {
-    int **p = GC_MALLOC(sizeof(int *));
-    int *q = GC_MALLOC_ATOMIC(sizeof(int));
+    int **p = (int**)GC_MALLOC(sizeof(int *));
+    int *q = (int*)GC_MALLOC_ATOMIC(sizeof(int));
 
     if (p == 0 || *p != 0) {
       fprintf(stderr, "GC_malloc returned garbage (or NULL)\n");
       exit(1);
     }
 
-    *p = GC_REALLOC(q, 2 * sizeof(int));
+    *p = (int*)GC_REALLOC(q, 2 * sizeof(int));
 
     if (i % 10 == 0) {
       unsigned long heap_size = (unsigned long)GC_get_heap_size();

--- a/tests/smash_test.c
+++ b/tests/smash_test.c
@@ -19,7 +19,7 @@ int main(void)
   GC_INIT();
 
   for (i = 0; i < COUNT; ++i) {
-     A[i] = p = GC_MALLOC(SIZE);
+     A[i] = p = (char*)GC_MALLOC(SIZE);
 
      if (i%3000 == 0) GC_gcollect();
      if (i%5678 == 0 && p != 0) p[SIZE + i/2000] = 42;

--- a/tests/test.c
+++ b/tests/test.c
@@ -1118,7 +1118,7 @@ const GC_word bm_huge[320 / CPP_WORDSZ] = {
 /* A very simple test of explicitly typed allocation    */
 void typed_test(void)
 {
-    GC_word * old, * new;
+    GC_word * old, * new_;
     GC_word bm3[1] = {0};
     GC_word bm2[1] = {0};
     GC_word bm_large[1] = { 0xf7ff7fff };
@@ -1144,61 +1144,61 @@ void typed_test(void)
     d2 = GC_make_descriptor(bm2, 2);
     old = 0;
     for (i = 0; i < 4000; i++) {
-        new = (GC_word *) GC_malloc_explicitly_typed(4 * sizeof(GC_word), d1);
-        CHECK_OUT_OF_MEMORY(new);
+        new_ = (GC_word *) GC_malloc_explicitly_typed(4 * sizeof(GC_word), d1);
+        CHECK_OUT_OF_MEMORY(new_);
         AO_fetch_and_add1(&collectable_count);
-        if (0 != new[0] || 0 != new[1]) {
+        if (0 != new_[0] || 0 != new_[1]) {
             GC_printf("Bad initialization by GC_malloc_explicitly_typed\n");
             FAIL;
         }
-        new[0] = 17;
-        new[1] = (GC_word)old;
-        old = new;
+        new_[0] = 17;
+        new_[1] = (GC_word)old;
+        old = new_;
         AO_fetch_and_add1(&collectable_count);
-        new = (GC_word *) GC_malloc_explicitly_typed(4 * sizeof(GC_word), d2);
-        CHECK_OUT_OF_MEMORY(new);
-        new[0] = 17;
-        new[1] = (GC_word)old;
-        old = new;
+        new_ = (GC_word *) GC_malloc_explicitly_typed(4 * sizeof(GC_word), d2);
+        CHECK_OUT_OF_MEMORY(new_);
+        new_[0] = 17;
+        new_[1] = (GC_word)old;
+        old = new_;
         AO_fetch_and_add1(&collectable_count);
-        new = (GC_word *) GC_malloc_explicitly_typed(33 * sizeof(GC_word), d3);
-        CHECK_OUT_OF_MEMORY(new);
-        new[0] = 17;
-        new[1] = (GC_word)old;
-        old = new;
+        new_ = (GC_word *) GC_malloc_explicitly_typed(33 * sizeof(GC_word), d3);
+        CHECK_OUT_OF_MEMORY(new_);
+        new_[0] = 17;
+        new_[1] = (GC_word)old;
+        old = new_;
         AO_fetch_and_add1(&collectable_count);
-        new = (GC_word *) GC_calloc_explicitly_typed(4, 2 * sizeof(GC_word),
+        new_ = (GC_word *) GC_calloc_explicitly_typed(4, 2 * sizeof(GC_word),
                                                      d1);
-        CHECK_OUT_OF_MEMORY(new);
-        new[0] = 17;
-        new[1] = (GC_word)old;
-        old = new;
+        CHECK_OUT_OF_MEMORY(new_);
+        new_[0] = 17;
+        new_[1] = (GC_word)old;
+        old = new_;
         AO_fetch_and_add1(&collectable_count);
         if (i & 0xff) {
-          new = (GC_word *) GC_calloc_explicitly_typed(7, 3 * sizeof(GC_word),
+          new_ = (GC_word *) GC_calloc_explicitly_typed(7, 3 * sizeof(GC_word),
                                                      d2);
         } else {
-          new = (GC_word *) GC_calloc_explicitly_typed(1001,
+          new_ = (GC_word *) GC_calloc_explicitly_typed(1001,
                                                        3 * sizeof(GC_word),
                                                        d2);
-          if (new && (0 != new[0] || 0 != new[1])) {
+          if (new_ && (0 != new_[0] || 0 != new_[1])) {
             GC_printf("Bad initialization by GC_malloc_explicitly_typed\n");
             FAIL;
           }
         }
-        CHECK_OUT_OF_MEMORY(new);
-        new[0] = 17;
-        new[1] = (GC_word)old;
-        old = new;
+        CHECK_OUT_OF_MEMORY(new_);
+        new_[0] = 17;
+        new_[1] = (GC_word)old;
+        old = new_;
     }
     for (i = 0; i < 20000; i++) {
-        if (new[0] != 17) {
+        if (new_[0] != 17) {
             GC_printf("Typed alloc failed at %d\n", i);
             FAIL;
         }
-        new[0] = 0;
-        old = new;
-        new = (GC_word *)(old[1]);
+        new_[0] = 0;
+        old = new_;
+        new_ = (GC_word *)(old[1]);
     }
     GC_gcollect();
     GC_noop1((word)x);
@@ -1306,7 +1306,7 @@ void run_one_test(void)
         FAIL;
       }
       AO_fetch_and_add1(&collectable_count);
-      x = GC_malloc(16);
+      x = (char*)GC_malloc(16);
       if (GC_base(GC_PTR_ADD(x, 13)) != x) {
         GC_printf("GC_base(heap ptr) produced incorrect result\n");
         FAIL;
@@ -1344,7 +1344,7 @@ void run_one_test(void)
         GC_printf("GC_is_visible produced incorrect result\n");
         FAIL;
       }
-      z = GC_malloc(8);
+      z = (char**)GC_malloc(8);
       CHECK_OUT_OF_MEMORY(z);
       AO_fetch_and_add1(&collectable_count);
       GC_PTR_STORE(z, x);
@@ -1393,11 +1393,11 @@ void run_one_test(void)
 #   endif /* DBG_HDRS_ALL */
     /* Test floating point alignment */
         {
-          double *dp = GC_MALLOC(sizeof(double));
+          double *dp = (double*)GC_MALLOC(sizeof(double));
           CHECK_OUT_OF_MEMORY(dp);
           AO_fetch_and_add1(&collectable_count);
           *dp = 1.0;
-          dp = GC_MALLOC(sizeof(double));
+          dp = (double*)GC_MALLOC(sizeof(double));
           CHECK_OUT_OF_MEMORY(dp);
           AO_fetch_and_add1(&collectable_count);
           *dp = 1.0;


### PR DESCRIPTION
Leave each header to decide if its content is extern "C" itself.
Except for very old C++-unaware systems that do not use extern "C", each header should own the C-ness of its declarations, and not have its clients determine it.