### PR TITLE
Fix gctest with musl libc on s390x

### DIFF
--- a/tests/test.c
+++ b/tests/test.c
@@ -2239,7 +2239,8 @@ int main(void)
     }
 #   if defined(GC_IRIX_THREADS) || defined(GC_FREEBSD_THREADS) \
         || defined(GC_DARWIN_THREADS) || defined(GC_AIX_THREADS) \
-        || defined(GC_OPENBSD_THREADS) || defined(DEFAULT_STACK_MAYBE_SMALL)
+        || defined(GC_OPENBSD_THREADS) || defined(DEFAULT_STACK_MAYBE_SMALL) \
+        || defined(NO_GETCONTEXT) /* musl libc */
         if ((code = pthread_attr_setstacksize(&attr, 1000 * 1024)) != 0) {
           GC_printf("pthread_attr_setstacksize failed, error=%d\n", code);
           FAIL;


### PR DESCRIPTION
Issue #202 (bdwgc).

DEFAULT_STACK_MAYBE_SMALL is only set if PARALLEL_MARK is set, but stack
is too small on musl libc even if PARALLEL_MARK is unset. We solve this
by detecting musl via NO_GETCONTEXT.