### PR TITLE
Receiving void* instead of char* is easier to use, as it requires no casting.

### DIFF
--- a/include/gc_mark.h
+++ b/include/gc_mark.h
@@ -281,9 +281,9 @@ GC_API void GC_CALL GC_set_mark_bit(const void *) GC_ATTR_NONNULL(1);
 /* (GC_push_conditional pushes either all or only dirty pages depending */
 /* on the third argument.)  GC_push_all_eager also ensures that stack   */
 /* is scanned immediately, not just scheduled for scanning.             */
-GC_API void GC_CALL GC_push_all(char * /* bottom */, char * /* top */);
-GC_API void GC_CALL GC_push_all_eager(char * /* bottom */, char * /* top */);
-GC_API void GC_CALL GC_push_conditional(char * /* bottom */, char * /* top */,
+GC_API void GC_CALL GC_push_all(volatile void * /* bottom */, volatile void * /* top */);
+GC_API void GC_CALL GC_push_all_eager(volatile void * /* bottom */, volatile void * /* top */);
+GC_API void GC_CALL GC_push_conditional(volatile void * /* bottom */, volatile void * /* top */,
                                         int /* bool all */);
 GC_API void GC_CALL GC_push_finalizer_structures(void);
 

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -1727,7 +1727,7 @@ GC_INNER GC_bool GC_collection_in_progress(void);
                         /* Collection is in progress, or was abandoned. */
 
 #define GC_PUSH_ALL_SYM(sym) \
-                GC_push_all((ptr_t)&(sym), (ptr_t)&(sym) + sizeof(sym))
+                GC_push_all(&(sym), &(sym) + 1)
 
 GC_INNER void GC_push_all_stack(ptr_t b, ptr_t t);
                                     /* As GC_push_all but consider      */

--- a/mark.c
+++ b/mark.c
@@ -1351,8 +1351,10 @@ GC_INNER void GC_mark_init(void)
  * Should only be used if there is no possibility of mark stack
  * overflow.
  */
-GC_API void GC_CALL GC_push_all(char *bottom, char *top)
+GC_API void GC_CALL GC_push_all(volatile void *vbottom, volatile void *vtop)
 {
+    char *bottom = (char *)vbottom;
+    char *top = (char *)vtop;
     register word length;
 
     bottom = (char *)(((word) bottom + ALIGNMENT-1) & ~(ALIGNMENT-1));
@@ -1399,7 +1401,7 @@ GC_API void GC_CALL GC_push_all(char *bottom, char *top)
         return;
     }
     if ((*dirty_fn)(h-1)) {
-        GC_push_all(bottom, (ptr_t)h);
+        GC_push_all(bottom, h);
     }
 
     while ((word)(h+1) <= (word)top) {
@@ -1407,25 +1409,27 @@ GC_API void GC_CALL GC_push_all(char *bottom, char *top)
             if ((word)(GC_mark_stack_top - GC_mark_stack)
                 > 3 * GC_mark_stack_size / 4) {
                 /* Danger of mark stack overflow */
-                GC_push_all((ptr_t)h, top);
+                GC_push_all(h, top);
                 return;
             } else {
-                GC_push_all((ptr_t)h, (ptr_t)(h+1));
+                GC_push_all(h, h+1);
             }
         }
         h++;
     }
 
     if ((ptr_t)h != top && (*dirty_fn)(h)) {
-       GC_push_all((ptr_t)h, top);
+       GC_push_all(h, top);
     }
     if ((word)GC_mark_stack_top >= (word)GC_mark_stack_limit) {
         ABORT("Unexpected mark stack overflow");
     }
   }
 
-  GC_API void GC_CALL GC_push_conditional(char *bottom, char *top, int all)
+  GC_API void GC_CALL GC_push_conditional(volatile void *vbottom, volatile void *vtop, int all)
   {
+    char *bottom = (char *)vbottom;
+    char *top = (char *)vtop;
     if (!all) {
       GC_push_selected((ptr_t)bottom, (ptr_t)top, GC_page_was_dirty);
     } else {
@@ -1441,7 +1445,7 @@ GC_API void GC_CALL GC_push_all(char *bottom, char *top)
     }
   }
 #else
-  GC_API void GC_CALL GC_push_conditional(char *bottom, char *top,
+  GC_API void GC_CALL GC_push_conditional(volatile void *bottom, volatile void *top,
                                           int all GC_ATTR_UNUSED)
   {
     GC_push_all(bottom, top);
@@ -1591,8 +1595,10 @@ GC_API void GC_CALL GC_print_trace(word gc_no)
  * change.
  */
 GC_ATTR_NO_SANITIZE_ADDR GC_ATTR_NO_SANITIZE_MEMORY GC_ATTR_NO_SANITIZE_THREAD
-GC_API void GC_CALL GC_push_all_eager(char *bottom, char *top)
+GC_API void GC_CALL GC_push_all_eager(volatile void *vbottom, volatile void *vtop)
 {
+    char *bottom = (char *)vbottom;
+    char *top = (char *)vtop;
     word * b = (word *)(((word) bottom + ALIGNMENT-1) & ~(ALIGNMENT-1));
     word * t = (word *)(((word) top) & ~(ALIGNMENT-1));
     register word *p;

--- a/mark_rts.c
+++ b/mark_rts.c
@@ -505,13 +505,13 @@ GC_API void GC_CALL GC_exclude_static_roots(void *b, void *e)
                                           GC_bool all);
 # define GC_PUSH_CONDITIONAL(b, t, all) \
                 (GC_parallel \
-                    ? GC_push_conditional_eager(b, t, all) \
-                    : GC_push_conditional((ptr_t)(b), (ptr_t)(t), all))
+                    ? GC_push_conditional_eager((b), (t), (all)) \
+                    : GC_push_conditional((b), (t), (all)))
 #elif defined(GC_DISABLE_INCREMENTAL)
-# define GC_PUSH_CONDITIONAL(b, t, all) GC_push_all((ptr_t)(b), (ptr_t)(t))
+# define GC_PUSH_CONDITIONAL(b, t, all) GC_push_all((b), (t))
 #else
 # define GC_PUSH_CONDITIONAL(b, t, all) \
-                GC_push_conditional((ptr_t)(b), (ptr_t)(t), all)
+                GC_push_conditional((b), (t), (all))
                         /* Do either of GC_push_all or GC_push_selected */
                         /* depending on the third arg.                  */
 #endif


### PR DESCRIPTION
Small downside is anyone using decltype(GC_push) in C++ function signatures
will get different name mangling.