### PR TITLE
FIX: issue #200

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1000,7 +1000,7 @@ AS_IF([test x"$with_libatomic_ops" != xno -a x"$with_libatomic_ops" != xnone],
 # autogen.sh (autoreconf); alternatively, comment out the following 3 lines.
 AS_IF([test x$missing_libatomic_ops = xtrue],
   [ PKG_CHECK_MODULES([ATOMIC_OPS], [atomic_ops],
-    [ missing_libatomic_ops=false ], [ [] ]) ])
+    [ missing_libatomic_ops=false ]) ])
 
 # Retry with AC_CHECK_HEADER if PKG_CHECK_MODULES failed.
 AS_IF([test x$missing_libatomic_ops = xtrue],

--- a/configure.ac
+++ b/configure.ac
@@ -1000,7 +1000,7 @@ AS_IF([test x"$with_libatomic_ops" != xno -a x"$with_libatomic_ops" != xnone],
 # autogen.sh (autoreconf); alternatively, comment out the following 3 lines.
 AS_IF([test x$missing_libatomic_ops = xtrue],
   [ PKG_CHECK_MODULES([ATOMIC_OPS], [atomic_ops],
-    [ missing_libatomic_ops=false ]) ])
+    [ missing_libatomic_ops=false ], [:]]) ])
 
 # Retry with AC_CHECK_HEADER if PKG_CHECK_MODULES failed.
 AS_IF([test x$missing_libatomic_ops = xtrue],


### PR DESCRIPTION
This is a fix for #200 .

I've hit this bug in CentOS, and the advised https://github.com/ivmai/bdwgc/issues/200#issuecomment-362389547 did not work.

The optional (empty) `[ACTION-IF-NOT-FOUND]` clause causes the `PKG_CHECK_MODULES` macro to fail on configure, even if `libatomic_ops` is found.

**EDIT**: single travis build failure seems unrelated