### PR TITLE
Fix root registration probrem on Win32

### DIFF
--- a/dyn_load.c
+++ b/dyn_load.c
@@ -1013,7 +1013,8 @@ GC_INNER void GC_register_dynamic_libraries(void)
             protect = buf.Protect;
             if (buf.State == MEM_COMMIT
                 && (protect == PAGE_EXECUTE_READWRITE
-                    || protect == PAGE_READWRITE)
+                    || protect == PAGE_READWRITE
+                    || protect == PAGE_WRITECOPY)
                 && (buf.Type == MEM_IMAGE
 #                   ifdef GC_REGISTER_MEM_PRIVATE
                       || (protect == PAGE_READWRITE && buf.Type == MEM_PRIVATE)


### PR DESCRIPTION
I updated Windows 10 to April 2018 Update yesterday.<br>
Then, 32-bit applications using Boehm GC are now terminating abnormally.<br>
<br>
It seems that the behavior of VirtualQuery() changed in April 2018 Update.<br>
In the past (Windows XP, Windows 7, and older Windows 10), VirtualQuery() always returned PAGE_READWRITE for the data section.<br>
In the April 2018 Update, it sometimes seems that PAGE_WRITECOPY is returned. (not always)<br>
<br>
![default](https://user-images.githubusercontent.com/18512546/39505236-eca425b0-4e0b-11e8-9da9-3566387d2f09.png)
<br><br>
When PAGE_WRITECOPY is returned for the data section, GC_register_dynamic_libraries() does not call GC_cond_add_roots(), so it is not registered as a route.<br>
Therefore, even if there is a reference from the global pointer variable, there arises a problem that the memory is collected.<br>
<br>
I added PAGE_WRITECOPY to the condition of GC_register_dynamic_libraries(), then my application now works on April 2018 Update.<br>
Please consider this matter.<br>
