### PR TITLE
mach/iOS12 fix

### DIFF
--- a/darwin_stop_world.c
+++ b/darwin_stop_world.c
@@ -560,7 +560,6 @@ GC_INNER void GC_stop_world(void)
 
   if (GC_query_task_threads) {
 #   ifndef GC_NO_THREADS_DISCOVERY
-      unsigned i;
       GC_bool changed;
       thread_act_array_t act_list, prev_list;
       mach_msg_type_number_t listcount, prevcount;


### PR DESCRIPTION
this PR fixes #231
* thread mach port is not deallocated when thread is saved in GC_mach_threads as it cause thread not being resumed as thread port object can be changed
* threads are now being suspended without check of suspend_count (as it can be suspended by app)
* changed logic of resume, now is primary cycle list are threads in GC_mach_threads

investigation and tech details are in series of posts(to long read as for comment) https://dkimitsa.github.io/2018/08/19/investigating-ios12-beta-crash-vol3/