### PR TITLE
Fix marks and hb_n_marks consistency when disclaim returns 1.

### DIFF
--- a/reclaim.c
+++ b/reclaim.c
@@ -238,6 +238,7 @@ STATIC ptr_t GC_reclaim_uninit(struct hblk *hbp, hdr *hhdr, word sz,
     while ((word)p <= (word)plim) {
         int marked = mark_bit_from_hdr(hhdr, bit_no);
         if (!marked && (*disclaim)(p)) {
+            set_mark_bit_from_hdr(hhdr, bit_no);
             hhdr -> hb_n_marks++;
             marked = 1;
         }


### PR DESCRIPTION
I think I found the issue behind the assertion failure in reclaim.c noted in #239:
```
* recalim.c: When a disclaim callback returns 1 to protect an object
from being reclaimed, mark it to skip it on repeated scans within the
cycle. In particular this fixes a failure of GC_ASSERT(sz * hhdr ->
hb_n_marks <= HBLKSIZE) due to excessive increments of hb_n_marks.
```
Setting the mark here seems to be the right thing to do; I must have though it was unnecessary, since the mark state would be cleared anyway after the reclaiming was done.

_Update_: Rebased on you fix of stat counters.