### PR TITLE
fix link with of bdw-gc with a system atomic_ops

### DIFF
--- a/bdw-gc.pc.in
+++ b/bdw-gc.pc.in
@@ -6,5 +6,5 @@ includedir=@includedir@
 Name: Boehm-Demers-Weiser Conservative Garbage Collector
 Description: A garbage collector for C and C++
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lgc
+Libs: -L${libdir} -lgc @ATOMIC_OPS_LIBS@
 Cflags: -I${includedir}

--- a/configure.ac
+++ b/configure.ac
@@ -1081,7 +1081,9 @@ AS_IF([test x"$with_libatomic_ops" = xno \
 AC_MSG_CHECKING([which libatomic_ops to use])
 AS_IF([test x"$with_libatomic_ops" != xno],
   [ AS_IF([test x"$with_libatomic_ops" != xnone -a x"$THREADS" != xnone],
-          [ AC_MSG_RESULT([external]) ],
+          [ AC_MSG_RESULT([external])
+            ATOMIC_OPS_LIBS="-latomic_ops"
+            AC_SUBST([ATOMIC_OPS_LIBS]) ],
           [ AC_MSG_RESULT([none])
             AS_IF([test x"$THREADS" != xnone],
                   [ AC_DEFINE([GC_BUILTIN_ATOMIC], [1],


### PR DESCRIPTION
When bdw-gc is linked with libatomic_ops, bdw-gc.pc must contain the
needed libraries (such as -latomic_ops) otherwise build of applications
such as guile will fail on link stage:

.libs/libguile_2.0_la-posix.o: In function `scm_tmpnam':
posix.c:(.text+0x2080): warning: the use of `tmpnam' is dangerous, better use `mkstemp'
  CCLD     guile
/home/buildroot/autobuild/run/instance-2/output/host/arm-buildroot-linux-gnueabi/sysroot/usr/lib/libgc.so: undefined reference to `AO_fetch_compare_and_swap_emulation'
/home/buildroot/autobuild/run/instance-2/output/host/arm-buildroot-linux-gnueabi/sysroot/usr/lib/libgc.so: undefined reference to `AO_store_full_emulation'

So set ATOMIC_OPS_LIBS to -latomic_ops when a system atomic_ops library
is used and use ATOMIC_OPS_LIBS in bdw-gc.pc.in

Fixes:
 - http://autobuild.buildroot.org/results/2b23d445e57a5e0f417f5cb9417b0a668bb7bf1c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>