### PR TITLE
Disclaim callbacks are incompatible with leak detection mode.

### DIFF
--- a/fnlz_mlc.c
+++ b/fnlz_mlc.c
@@ -94,6 +94,8 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_finalized_malloc(size_t lb,
 {
     word *op;
 
+    if (EXPECT(GC_find_leak, FALSE))
+        return NULL;
     GC_ASSERT(GC_finalized_kind != 0);
     GC_ASSERT(NONNULL_ARG_NOT_NULL(fclos));
     GC_ASSERT(((word)fclos & FINALIZER_CLOSURE_FLAG) == 0);

--- a/include/gc_disclaim.h
+++ b/include/gc_disclaim.h
@@ -39,6 +39,8 @@ typedef int (GC_CALLBACK * GC_disclaim_proc)(void * /*obj*/);
 /* (including the referred closure object) will be protected from       */
 /* collection if "mark_from_all" is non-zero, but at the expense that   */
 /* long chains of objects will take many cycles to reclaim.             */
+/* Calls to GC_free will free its argument without inquiring "proc".    */
+/* Disclaim notifiers are incompatible with leak detection mode.        */
 GC_API void GC_CALL GC_register_disclaim_proc(int /*kind*/,
                                 GC_disclaim_proc /*proc*/,
                                 int /*mark_from_all*/) GC_ATTR_NONNULL(2);
@@ -60,6 +62,8 @@ struct GC_finalizer_closure {
 /* Note that GC_size (applied to such allocated object) returns a value */
 /* slightly bigger than the specified allocation size, and that GC_base */
 /* result points to a word prior to the start of the allocated object.  */
+/* This function is incompatible with leak detection mode and will      */
+/* return NULL if GC_find_leak has already been set.                    */
 GC_API GC_ATTR_MALLOC GC_ATTR_ALLOC_SIZE(1) void * GC_CALL
         GC_finalized_malloc(size_t /*size*/,
                 const struct GC_finalizer_closure * /*fc*/) GC_ATTR_NONNULL(2);

--- a/tests/disclaim_bench.c
+++ b/tests/disclaim_bench.c
@@ -16,6 +16,16 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifdef FIND_LEAK
+
+int main(void)
+{
+  printf("disclaim_bench skipped in leak detection mode.\n");
+  return 0;
+}
+
+#else
+
 #ifdef HAVE_CONFIG_H
 # include "config.h"
 #endif
@@ -158,3 +168,5 @@ int main(int argc, char **argv)
     }
     return 0;
 }
+
+#endif /* FIND_LEAK */

--- a/tests/disclaim_test.c
+++ b/tests/disclaim_test.c
@@ -20,6 +20,16 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifdef FIND_LEAK
+
+int main(void)
+{
+  printf("disclaim_weakmap_test skipped in leak detection mode.\n");
+  return 0;
+}
+
+#else
+
 #ifdef HAVE_CONFIG_H
   /* For GC_[P]THREADS */
 # include "config.h"
@@ -270,3 +280,5 @@ int main(void)
 # endif
     return 0;
 }
+
+#endif /* FIND_LEAK */

--- a/tests/disclaim_weakmap_test.c
+++ b/tests/disclaim_weakmap_test.c
@@ -18,6 +18,16 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef FIND_LEAK
+
+int main(void)
+{
+  printf("disclaim_weakmap_test skipped in leak detection mode.\n");
+  return 0;
+}
+
+#else
+
 #ifdef HAVE_CONFIG_H
   /* For GC_[P]THREADS */
 # include "config.h"
@@ -471,3 +481,5 @@ int main(void)
          (unsigned)stat_added - (unsigned)stat_removed);
   return 0;
 }
+
+#endif /* FIND_LEAK */


### PR DESCRIPTION
This is my proposal for #252.

* fnlz_mlc.c (GC_finalized_malloc): Return NULL if GC_find_leak.
* include/gc_disclaim.h: Document incompatibility with leak detection
  mode and GC_free.
* tests/disclaim_bench.c: Skip for leak detection mode.
* tests/disclaim_test.c: Likewise.
* tests/disclaim_weakmap_test.c: Likewise.