### PR TITLE
No dynamic exceptions in ISO C++17

### DIFF
--- a/gc_cpp.cc
+++ b/gc_cpp.cc
@@ -53,7 +53,11 @@ GC_API void GC_CALL GC_throw_bad_alloc() {
 # endif
 
 # ifdef GC_NEW_DELETE_NEED_THROW
-#   define GC_DECL_NEW_THROW throw(std::bad_alloc)
+#   if __cplusplus < 201703L
+#     define GC_DECL_NEW_THROW throw(std::bad_alloc)
+#   else
+#     define GC_DECL_NEW_THROW noexcept(false)
+#   endif
 # else
 #   define GC_DECL_NEW_THROW /* empty */
 # endif


### PR DESCRIPTION
Building clang 8 (and -std=c++1z) fails. The error message produced is:
```
/mnt/build/jenkins/workspace/lcg_release_latest/BUILDTYPE/Release/COMPILER/clang800binutils/LABEL/centos7/build/externals/madx-5.05.01/src/madx/5.05.01/libs/gc/gc-8.0.2/gc_cpp.cc:61:35: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
  void* operator new(size_t size) GC_DECL_NEW_THROW {
                                  ^~~~~~~~~~~~~~~~~
/mnt/build/jenkins/workspace/lcg_release_latest/BUILDTYPE/Release/COMPILER/clang800binutils/LABEL/centos7/build/externals/madx-5.05.01/src/madx/5.05.01/libs/gc/gc-8.0.2/gc_cpp.cc:56:30: note: expanded from macro 'GC_DECL_NEW_THROW'
#   define GC_DECL_NEW_THROW throw(std::bad_alloc)
                             ^~~~~~~~~~~~~~~~~~~~~
/mnt/build/jenkins/workspace/lcg_release_latest/BUILDTYPE/Release/COMPILER/clang800binutils/LABEL/centos7/build/externals/madx-5.05.01/src/madx/5.05.01/libs/gc/gc-8.0.2/gc_cpp.cc:61:35: note: use 'noexcept(false)' instead
  void* operator new(size_t size) GC_DECL_NEW_THROW {
                                  ^~~~~~~~~~~~~~~~~
                                  noexcept(false)
/mnt/build/jenkins/workspace/lcg_release_latest/BUILDTYPE/Release/COMPILER/clang800binutils/LABEL/centos7/build/externals/madx-5.05.01/src/madx/5.05.01/libs/gc/gc-8.0.2/gc_cpp.cc:56:30: note: expanded from macro 'GC_DECL_NEW_THROW'
#   define GC_DECL_NEW_THROW throw(std::bad_alloc)
                             ^
/mnt/build/jenkins/workspace/lcg_release_latest/BUILDTYPE/Release/COMPILER/clang800binutils/LABEL/centos7/build/externals/madx-5.05.01/src/madx/5.05.01/libs/gc/gc-8.0.2/gc_cpp.cc:73:39: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
    void* operator new[](size_t size) GC_DECL_NEW_THROW {
                                      ^~~~~~~~~~~~~~~~~
/mnt/build/jenkins/workspace/lcg_release_latest/BUILDTYPE/Release/COMPILER/clang800binutils/LABEL/centos7/build/externals/madx-5.05.01/src/madx/5.05.01/libs/gc/gc-8.0.2/gc_cpp.cc:56:30: note: expanded from macro 'GC_DECL_NEW_THROW'
#   define GC_DECL_NEW_THROW throw(std::bad_alloc)
                             ^~~~~~~~~~~~~~~~~~~~~
/mnt/build/jenkins/workspace/lcg_release_latest/BUILDTYPE/Release/COMPILER/clang800binutils/LABEL/centos7/build/externals/madx-5.05.01/src/madx/5.05.01/libs/gc/gc-8.0.2/gc_cpp.cc:73:39: note: use 'noexcept(false)' instead
    void* operator new[](size_t size) GC_DECL_NEW_THROW {
                                      ^~~~~~~~~~~~~~~~~
                                      noexcept(false)
/mnt/build/jenkins/workspace/lcg_release_latest/BUILDTYPE/Release/COMPILER/clang800binutils/LABEL/centos7/build/externals/madx-5.05.01/src/madx/5.05.01/libs/gc/gc-8.0.2/gc_cpp.cc:56:30: note: expanded from macro 'GC_DECL_NEW_THROW'
#   define GC_DECL_NEW_THROW throw(std::bad_alloc)
                             ^
2 errors generated.
```

The "dynamic exception" syntax was declared deprecated in C++11 and is removed in C++17, see [P0003](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0003r5.html).