### PR TITLE
Allocate the start_info struct on the stack in GC_pthread_create.

### DIFF
--- a/pthread_support.c
+++ b/pthread_support.c
@@ -1892,7 +1892,7 @@ GC_INNER_PTHRSTART GC_thread GC_start_rtn_prepare_thread(
     int result;
     int detachstate;
     word my_flags = 0;
-    struct start_info * si;
+    struct start_info si;
     DCL_LOCK_STATE;
         /* This is otherwise saved only in an area mmapped by the thread */
         /* library, which isn't visible to the collector.                */
@@ -1902,21 +1902,13 @@ GC_INNER_PTHRSTART GC_thread GC_start_rtn_prepare_thread(
     /* responsibility.                                                  */
 
     INIT_REAL_SYMS();
-    LOCK();
-    si = (struct start_info *)GC_INTERNAL_MALLOC(sizeof(struct start_info),
-                                                 NORMAL);
-    UNLOCK();
     if (!EXPECT(parallel_initialized, TRUE))
       GC_init_parallel();
-    if (EXPECT(0 == si, FALSE) &&
-        (si = (struct start_info *)
-                (*GC_get_oom_fn())(sizeof(struct start_info))) == 0)
-      return(ENOMEM);
-    if (sem_init(&(si -> registered), GC_SEM_INIT_PSHARED, 0) != 0)
+    if (sem_init(&si.registered, GC_SEM_INIT_PSHARED, 0) != 0)
       ABORT("sem_init failed");
 
-    si -> start_routine = start_routine;
-    si -> arg = arg;
+    si.start_routine = start_routine;
+    si.arg = arg;
     LOCK();
     if (!EXPECT(GC_thr_initialized, TRUE))
       GC_thr_init();
@@ -1956,19 +1948,16 @@ GC_INNER_PTHRSTART GC_thread GC_start_rtn_prepare_thread(
         pthread_attr_getdetachstate(attr, &detachstate);
     }
     if (PTHREAD_CREATE_DETACHED == detachstate) my_flags |= DETACHED;
-    si -> flags = my_flags;
+    si.flags = my_flags;
     UNLOCK();
 #   ifdef DEBUG_THREADS
       GC_log_printf("About to start new thread from thread %p\n",
                     (void *)pthread_self());
 #   endif
     set_need_to_lock();
-    result = REAL_FUNC(pthread_create)(new_thread, attr, GC_start_routine, si);
+    result = REAL_FUNC(pthread_create)(new_thread, attr, GC_start_routine, &si);
 
     /* Wait until child has been added to the thread table.             */
-    /* This also ensures that we hold onto si until the child is done   */
-    /* with it.  Thus it doesn't matter whether it is otherwise         */
-    /* visible to the collector.                                        */
     if (0 == result) {
         IF_CANCEL(int cancel_state;)
 
@@ -1978,7 +1967,7 @@ GC_INNER_PTHRSTART GC_thread GC_start_rtn_prepare_thread(
 #       endif
         DISABLE_CANCEL(cancel_state);
                 /* pthread_create is not a cancellation point. */
-        while (0 != sem_wait(&(si -> registered))) {
+        while (0 != sem_wait(&si.registered)) {
 #           if defined(GC_HAIKU_THREADS)
               /* To workaround some bug in Haiku semaphores. */
               if (EACCES == errno) continue;
@@ -1987,10 +1976,7 @@ GC_INNER_PTHRSTART GC_thread GC_start_rtn_prepare_thread(
         }
         RESTORE_CANCEL(cancel_state);
     }
-    sem_destroy(&(si -> registered));
-    LOCK();
-    GC_INTERNAL_FREE(si);
-    UNLOCK();
+    sem_destroy(&si.registered);
 
     return(result);
   }


### PR DESCRIPTION
Allocating the start_info struct on the stack in the GC_pthread_create function fixes a random crash when sem_wait is called on freed memory.

Issue #296.