### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,15 @@ or win16 is hard.
 For machines not already mentioned, or for nonstandard compilers,
 some porting suggestions are provided [here](doc/porting.md).
 
+You can download and install bdwgc using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install bdwgc
+    
+The bdwgc port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## The C Interface to the Allocator
 


### PR DESCRIPTION
`bdwgc` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `bdwgc` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `bdwgc`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, arm, uwp) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/bdwgc/portfile.cmake). We try to keep the library maintained as close as possible to the original library.