### PR TITLE
Add threading libraries to bdw-gc.pc

### DIFF
--- a/bdw-gc.pc.in
+++ b/bdw-gc.pc.in
@@ -6,5 +6,5 @@ includedir=@includedir@
 Name: Boehm-Demers-Weiser Conservative Garbage Collector
 Description: A garbage collector for C and C++
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} @ATOMIC_OPS_LIBS@ -lgc
+Libs: -L${libdir} @ATOMIC_OPS_LIBS@ -lgc @THREADDLLIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
This is important when building static libraries. In that case the
application must link in all transitive dependencies. Right now using
only the flags from `pkg-config --cflags --libs .../bdw-gc.pc` results
in many undefined references to `pthread_*` functions.