### PR TITLE
Add missing gc_dlopen.c to CMake configuration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ include_directories(include)
 set(SRC alloc.c reclaim.c allchblk.c misc.c mach_dep.c os_dep.c
         mark_rts.c headers.c mark.c obj_map.c blacklst.c finalize.c
         new_hblk.c dbg_mlc.c malloc.c dyn_load.c typd_mlc.c ptr_chck.c
-        mallocx.c)
+        mallocx.c gc_dlopen.c)
 set(THREADDLLIBS)
 
 set(_HOST ${CMAKE_SYSTEM_PROCESSOR}-unknown-${CMAKE_SYSTEM})


### PR DESCRIPTION
  - The source file _gc_dlopen.c_ is not listed in the SRC variable of the
    CMake configuration. This leads to undefined references of GC_dlopen
    when the library is built as a STATIC library.

  - When building as shared library it does not happen because the SRC
    variable listing all source files is overridden to contain only the
    single source extra/gc.c (ehich I assume contains the missing definition

Related issue #335 