### PR TITLE
Add support of FreeBSD/RISC-V

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -663,7 +663,7 @@ EXTERN_C_BEGIN
 #   endif
 #   define mach_type_known
 # endif
-# if defined(__riscv) && defined(LINUX)
+# if defined(__riscv) && (defined(LINUX) || defined(FREEBSD))
 #   define RISCV
 #   define mach_type_known
 # endif
@@ -2938,6 +2938,19 @@ EXTERN_C_BEGIN
 #     define DATASTART ((ptr_t)__data_start)
 #     define LINUX_STACKBOTTOM
 #     define DYNAMIC_LOADING
+#   endif
+#   ifdef FREEBSD
+#     define OS_TYPE "FREEBSD"
+#     ifndef GC_FREEBSD_THREADS
+#       define MPROTECT_VDB
+#     endif
+#     define SIG_SUSPEND SIGUSR1
+#     define SIG_THR_RESTART SIGUSR2
+#     define FREEBSD_STACKBOTTOM
+#     define DYNAMIC_LOADING
+      extern char etext[];
+#     define DATASTART GC_FreeBSDGetDataStart(0x1000, (ptr_t)etext)
+#     define DATASTART_USES_BSDGETDATASTART
 #   endif
 # endif /* RISCV */
 


### PR DESCRIPTION
I'm maintainer of FreeBSD BDWGC port. Recently I received bug report from a user that the port can't be built on FreeBSD/RISC-V environment. I checked source code and found that currently Linux is only supported OS of RISC-V architecture. So I replied that currently FreeBSD/RISC-V isn't supported but if someone provides patch then I'll accept it. Then another user provided it and he said that it passes `make check` test. Since I don't have way to access FreeBSD/RISC-V environment, I can't test it by myself. But anyway I decided to create pull request as feedback to upstream.
