### PR TITLE
docs: fix simple typo, meachine -> machine

### DIFF
--- a/extra/msvc_dbg.c
+++ b/extra/msvc_dbg.c
@@ -22,7 +22,7 @@
 
 #if !defined(_M_X64) && defined(_MSC_VER)
 
-/* X86_64 is currently missing some meachine-dependent code below.  */
+/* X86_64 is currently missing some machine-dependent code below.  */
 
 #define GC_BUILD
 #include "private/msvc_dbg.h"


### PR DESCRIPTION
There is a small typo in extra/msvc_dbg.c.

Should read `machine` rather than `meachine`.

