### PR TITLE
Update OpenBSD support for 8.0 branch

### DIFF
--- a/dyn_load.c
+++ b/dyn_load.c
@@ -81,13 +81,6 @@ STATIC GC_has_static_roots_func GC_has_static_roots = 0;
 #   define ELFSIZE ARCH_ELFSIZE
 #endif
 
-#if defined(OPENBSD)
-# include <sys/param.h>
-# if (OpenBSD >= 200519) && !defined(HAVE_DL_ITERATE_PHDR)
-#   define HAVE_DL_ITERATE_PHDR
-# endif
-#endif /* OPENBSD */
-
 #if defined(SCO_ELF) || defined(DGUX) || defined(HURD) \
     || (defined(__ELF__) && (defined(LINUX) || defined(FREEBSD) \
                              || defined(NACL) || defined(NETBSD) \
@@ -150,8 +143,10 @@ STATIC GC_has_static_roots_func GC_has_static_roots = 0;
 #    elif defined(NETBSD) || defined(OPENBSD)
 #      if ELFSIZE == 32
 #        define ElfW(type) Elf32_##type
-#      else
+#      elif ELFSIZE == 64
 #        define ElfW(type) Elf64_##type
+#      else
+#        error Missing required ELFSIZE define
 #      endif
 #    else
 #      if !defined(ELF_CLASS) || ELF_CLASS == ELFCLASS32

--- a/include/gc_config_macros.h
+++ b/include/gc_config_macros.h
@@ -83,13 +83,13 @@
 #elif defined(GC_THREADS)
 # if defined(__linux__)
 #   define GC_LINUX_THREADS
+# elif defined(__OpenBSD__)
+#   define GC_OPENBSD_THREADS
 # elif defined(_PA_RISC1_1) || defined(_PA_RISC2_0) || defined(hppa) \
        || defined(__HPPA) || (defined(__ia64) && defined(_HPUX_SOURCE))
 #   define GC_HPUX_THREADS
 # elif defined(__HAIKU__)
 #   define GC_HAIKU_THREADS
-# elif defined(__OpenBSD__)
-#   define GC_OPENBSD_THREADS
 # elif defined(__DragonFly__) || defined(__FreeBSD_kernel__) \
        || (defined(__FreeBSD__) && !defined(SN_TARGET_ORBIS))
 #   define GC_FREEBSD_THREADS

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -2608,9 +2608,7 @@ GC_INNER void *GC_store_debug_info_inner(void *p, word sz, const char *str,
 #     define SIG_SUSPEND SIGPWR
 #   endif
 # elif defined(GC_OPENBSD_THREADS)
-#   ifndef GC_OPENBSD_UTHREADS
-#     define SIG_SUSPEND SIGXFSZ
-#   endif
+#   define SIG_SUSPEND SIGXFSZ
 # elif defined(_SIGRTMIN) && !defined(CPPCHECK)
 #   define SIG_SUSPEND _SIGRTMIN + 6
 # else

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -2895,6 +2895,8 @@ EXTERN_C_BEGIN
     /* The kernel may do a somewhat better job merging mappings etc.    */
     /* with anonymous mappings.                                         */
 #   define USE_MMAP_ANON
+#elif defined(OPENBSD) && defined(USE_MMAP)
+#   define USE_MMAP_ANON
 #endif
 
 #if defined(GC_LINUX_THREADS) && defined(REDIRECT_MALLOC) \

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -3106,17 +3106,6 @@ EXTERN_C_BEGIN
 # define GC_NETBSD_THREADS_WORKAROUND
 #endif
 
-#ifdef GC_OPENBSD_THREADS
-  EXTERN_C_END
-# include <sys/param.h>
-  EXTERN_C_BEGIN
-  /* Prior to 5.2 release, OpenBSD had user threads and required        */
-  /* special handling.                                                  */
-# if OpenBSD < 201211
-#   define GC_OPENBSD_UTHREADS 1
-# endif
-#endif /* GC_OPENBSD_THREADS */
-
 #if defined(SVR4) || defined(LINUX) || defined(IRIX5) || defined(HPUX) \
     || defined(OPENBSD) || defined(NETBSD) || defined(FREEBSD) \
     || defined(DGUX) || defined(BSD) || defined(HAIKU) || defined(HURD) \

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1083,7 +1083,12 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
-#     define ALIGNMENT 4
+#     if defined(__powerpc64__)
+#       define ALIGNMENT 8
+#       define CPP_WORDSZ 64
+#     else
+#       define ALIGNMENT 4
+#     endif
 #     ifndef GC_OPENBSD_THREADS
 #       define HEURISTIC2
 #     endif

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1085,17 +1085,7 @@ EXTERN_C_BEGIN
 #     define OS_TYPE "OPENBSD"
 #     define ALIGNMENT 4
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-        /* USRSTACK is defined in <machine/vmparam.h> but that is       */
-        /* protected by _KERNEL in <uvm/uvm_param.h> file.              */
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -1311,15 +1301,7 @@ EXTERN_C_BEGIN
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -1612,15 +1594,7 @@ EXTERN_C_BEGIN
 #   ifdef OPENBSD
 #       define OS_TYPE "OPENBSD"
 #       ifndef GC_OPENBSD_THREADS
-          EXTERN_C_END
-#         include <sys/param.h>
-#         include <uvm/uvm_extern.h>
-          EXTERN_C_BEGIN
-#         ifdef USRSTACK
-#           define STACKBOTTOM ((ptr_t)USRSTACK)
-#         else
-#           define HEURISTIC2
-#         endif
+#         define HEURISTIC2
 #       endif
         extern int __data_start[];
 #       define DATASTART ((ptr_t)__data_start)
@@ -1861,15 +1835,7 @@ EXTERN_C_BEGIN
 #     define CPP_WORDSZ 64 /* all OpenBSD/mips platforms are 64-bit */
 #     define ALIGNMENT 8
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -2007,15 +1973,7 @@ EXTERN_C_BEGIN
 #  ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -2043,15 +2001,7 @@ EXTERN_C_BEGIN
 #       define OS_TYPE "OPENBSD"
 #       define ELF_CLASS ELFCLASS64
 #       ifndef GC_OPENBSD_THREADS
-          EXTERN_C_END
-#         include <sys/param.h>
-#         include <uvm/uvm_extern.h>
-          EXTERN_C_BEGIN
-#         ifdef USRSTACK
-#           define STACKBOTTOM ((ptr_t)USRSTACK)
-#         else
-#           define HEURISTIC2
-#         endif
+#         define HEURISTIC2
 #       endif
         extern int __data_start[];
 #       define DATASTART ((ptr_t)__data_start)
@@ -2361,15 +2311,7 @@ EXTERN_C_BEGIN
 #     define OS_TYPE "OPENBSD"
 #     define ELF_CLASS ELFCLASS64
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -2497,15 +2439,7 @@ EXTERN_C_BEGIN
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -2582,15 +2516,7 @@ EXTERN_C_BEGIN
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -2660,15 +2586,7 @@ EXTERN_C_BEGIN
 #       define OS_TYPE "OPENBSD"
 #       define ELF_CLASS ELFCLASS64
 #       ifndef GC_OPENBSD_THREADS
-          EXTERN_C_END
-#         include <sys/param.h>
-#         include <uvm/uvm_extern.h>
-          EXTERN_C_BEGIN
-#         ifdef USRSTACK
-#           define STACKBOTTOM ((ptr_t)USRSTACK)
-#         else
-#           define HEURISTIC2
-#         endif
+#         define HEURISTIC2
 #       endif
         extern int __data_start[];
         extern int _end[];

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1999,7 +1999,6 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef OPENBSD
 #       define OS_TYPE "OPENBSD"
-#       define ELF_CLASS ELFCLASS64
 #       ifndef GC_OPENBSD_THREADS
 #         define HEURISTIC2
 #       endif
@@ -2309,7 +2308,6 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
-#     define ELF_CLASS ELFCLASS64
 #     ifndef GC_OPENBSD_THREADS
 #       define HEURISTIC2
 #     endif
@@ -2584,7 +2582,6 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef OPENBSD
 #       define OS_TYPE "OPENBSD"
-#       define ELF_CLASS ELFCLASS64
 #       ifndef GC_OPENBSD_THREADS
 #         define HEURISTIC2
 #       endif

--- a/include/private/pthread_stop_world.h
+++ b/include/private/pthread_stop_world.h
@@ -21,8 +21,8 @@
 EXTERN_C_BEGIN
 
 struct thread_stop_info {
-#   if !defined(GC_OPENBSD_UTHREADS) && !defined(NACL) \
-       && !defined(SN_TARGET_ORBIS) && !defined(SN_TARGET_PSP2)
+#   if !defined(NACL) && !defined(SN_TARGET_ORBIS) \
+       && !defined(SN_TARGET_PSP2)
       volatile AO_t last_stop_count;
                         /* The value of GC_stop_count when the thread   */
                         /* last successfully handled a suspend signal.  */

--- a/include/private/pthread_support.h
+++ b/include/private/pthread_support.h
@@ -67,7 +67,7 @@ typedef struct GC_Thread_Rep {
     struct thread_stop_info stop_info;
 
 #   if defined(GC_ENABLE_SUSPEND_THREAD) && !defined(GC_DARWIN_THREADS) \
-        && !defined(GC_OPENBSD_UTHREADS) && !defined(NACL)
+        && !defined(NACL)
       volatile AO_t suspended_ext;  /* Thread was suspended externally. */
 #   endif
 

--- a/misc.c
+++ b/misc.c
@@ -606,8 +606,8 @@ GC_API void GC_CALL GC_get_heap_usage_safe(GC_word *pheap_size,
 
 #endif /* !GC_GET_HEAP_USAGE_NOT_NEEDED */
 
-#if defined(GC_DARWIN_THREADS) || defined(GC_OPENBSD_UTHREADS) \
-    || defined(GC_WIN32_THREADS) || (defined(NACL) && defined(THREADS))
+#if defined(GC_DARWIN_THREADS) || defined(GC_WIN32_THREADS) \
+    || (defined(NACL) && defined(THREADS))
   /* GC does not use signals to suspend and restart threads.    */
   GC_API void GC_CALL GC_set_suspend_signal(int sig GC_ATTR_UNUSED)
   {

--- a/os_dep.c
+++ b/os_dep.c
@@ -516,64 +516,9 @@ GC_INNER char * GC_get_maps(void)
   static struct sigaction old_segv_act;
   STATIC JMP_BUF GC_jmp_buf_openbsd;
 
-# ifdef THREADS
-#   include <sys/syscall.h>
-    EXTERN_C_BEGIN
-    extern sigset_t __syscall(quad_t, ...);
-    EXTERN_C_END
-# endif
-
-  /* Don't use GC_find_limit() because siglongjmp() outside of the      */
-  /* signal handler by-passes our userland pthreads lib, leaving        */
-  /* SIGSEGV and SIGPROF masked.  Instead, use this custom one that     */
-  /* works-around the issues.                                           */
-
   STATIC void GC_fault_handler_openbsd(int sig GC_ATTR_UNUSED)
   {
      LONGJMP(GC_jmp_buf_openbsd, 1);
-  }
-
-  /* Return the first non-addressable location > p or bound.    */
-  /* Requires the allocation lock.                              */
-  STATIC ptr_t GC_find_limit_openbsd(ptr_t p, ptr_t bound)
-  {
-    static volatile ptr_t result;
-             /* Safer if static, since otherwise it may not be  */
-             /* preserved across the longjmp.  Can safely be    */
-             /* static since it's only called with the          */
-             /* allocation lock held.                           */
-
-    struct sigaction act;
-    word pgsz = (word)sysconf(_SC_PAGESIZE);
-
-    GC_ASSERT((word)bound >= pgsz);
-    GC_ASSERT(I_HOLD_LOCK());
-
-    act.sa_handler = GC_fault_handler_openbsd;
-    sigemptyset(&act.sa_mask);
-    act.sa_flags = SA_NODEFER | SA_RESTART;
-    /* act.sa_restorer is deprecated and should not be initialized. */
-    sigaction(SIGSEGV, &act, &old_segv_act);
-
-    if (SETJMP(GC_jmp_buf_openbsd) == 0) {
-      result = (ptr_t)((word)p & ~(pgsz-1));
-      for (;;) {
-        if ((word)result >= (word)bound - pgsz) {
-          result = bound;
-          break;
-        }
-        result += pgsz; /* no overflow expected */
-        GC_noop1((word)(*result));
-      }
-    }
-
-#   ifdef THREADS
-      /* Due to the siglongjump we need to manually unmask SIGPROF.     */
-      __syscall(SYS_sigprocmask, SIG_UNBLOCK, sigmask(SIGPROF));
-#   endif
-
-    sigaction(SIGSEGV, &old_segv_act, 0);
-    return(result);
   }
 
   /* Return first addressable location > p or bound.    */
@@ -2006,7 +1951,8 @@ void GC_register_data_segments(void)
     ABORT_ARG2("Wrong DATASTART/END pair",
                ": %p .. %p", (void *)region_start, (void *)DATAEND);
   for (;;) {
-    ptr_t region_end = GC_find_limit_openbsd(region_start, DATAEND);
+    ptr_t region_end = GC_find_limit_with_bound(region_start, TRUE,
+                                                DATAEND);
 
     GC_add_roots_inner(region_start, region_end, FALSE);
     if ((word)region_end >= (word)DATAEND)
@@ -3317,8 +3263,7 @@ GC_API GC_push_other_roots_proc GC_CALL GC_get_push_other_roots(void)
       act.sa_flags = SA_RESTART | SA_SIGINFO;
       act.sa_sigaction = GC_write_fault_handler;
       (void)sigemptyset(&act.sa_mask);
-#     if defined(THREADS) && !defined(GC_OPENBSD_UTHREADS) \
-         && !defined(GC_WIN32_THREADS) && !defined(NACL)
+#     if defined(THREADS) && !defined(GC_WIN32_THREADS) && !defined(NACL)
         /* Arrange to postpone the signal while we are in a write fault */
         /* handler.  This effectively makes the handler atomic w.r.t.   */
         /* stopping the world for GC.                                   */

--- a/pthread_stop_world.c
+++ b/pthread_stop_world.c
@@ -36,11 +36,7 @@
   volatile int GC_nacl_thread_parked[MAX_NACL_GC_THREADS];
   int GC_nacl_thread_used[MAX_NACL_GC_THREADS];
 
-#elif defined(GC_OPENBSD_UTHREADS)
-
-# include <pthread_np.h>
-
-#else /* !GC_OPENBSD_UTHREADS && !NACL */
+#else /* !NACL */
 
 #include <signal.h>
 #include <semaphore.h>
@@ -652,7 +648,7 @@ STATIC void GC_restart_handler(int sig)
 # undef ao_load_async
 # undef ao_store_async
 # undef ao_store_release_async
-#endif /* !GC_OPENBSD_UTHREADS && !NACL */
+#endif /* !NACL */
 
 #ifdef IA64
 # define IF_IA64(x) x
@@ -771,9 +767,7 @@ STATIC int GC_suspend_all(void)
   int i;
 # ifndef NACL
     GC_thread p;
-#   ifndef GC_OPENBSD_UTHREADS
-      int result;
-#   endif
+    int result;
     pthread_t self = pthread_self();
 
     for (i = 0; i < THREAD_TABLE_SZ; i++) {
@@ -781,56 +775,37 @@ STATIC int GC_suspend_all(void)
         if (!THREAD_EQUAL(p -> id, self)) {
             if ((p -> flags & FINISHED) != 0) continue;
             if (p -> thread_blocked) /* Will wait */ continue;
-#           ifndef GC_OPENBSD_UTHREADS
-#             ifdef GC_ENABLE_SUSPEND_THREAD
-                if (p -> suspended_ext) continue;
-#             endif
-              if (AO_load(&p->stop_info.last_stop_count) == GC_stop_count)
-                continue; /* matters only if GC_retry_signals */
-              n_live_threads++;
+#           ifdef GC_ENABLE_SUSPEND_THREAD
+              if (p -> suspended_ext) continue;
 #           endif
+            if (AO_load(&p->stop_info.last_stop_count) == GC_stop_count)
+              continue; /* matters only if GC_retry_signals */
+            n_live_threads++;
 #           ifdef DEBUG_THREADS
               GC_log_printf("Sending suspend signal to %p\n", (void *)p->id);
 #           endif
 
-#           ifdef GC_OPENBSD_UTHREADS
-              {
-                stack_t stack;
-
-                GC_acquire_dirty_lock();
-                if (pthread_suspend_np(p -> id) != 0)
-                  ABORT("pthread_suspend_np failed");
-                GC_release_dirty_lock();
-                if (pthread_stackseg_np(p->id, &stack))
-                  ABORT("pthread_stackseg_np failed");
-                p -> stop_info.stack_ptr = (ptr_t)stack.ss_sp - stack.ss_size;
-                if (GC_on_thread_event)
-                  GC_on_thread_event(GC_EVENT_THREAD_SUSPENDED,
-                                     (void *)p->id);
-              }
-#           else
-              /* The synchronization between GC_dirty (based on         */
-              /* test-and-set) and the signal-based thread suspension   */
-              /* is performed in GC_stop_world because                  */
-              /* GC_release_dirty_lock cannot be called before          */
-              /* acknowledging the thread is really suspended.          */
-              result = RAISE_SIGNAL(p, GC_sig_suspend);
-              switch(result) {
-                case ESRCH:
-                    /* Not really there anymore.  Possible? */
-                    n_live_threads--;
-                    break;
-                case 0:
-                    if (GC_on_thread_event)
-                      GC_on_thread_event(GC_EVENT_THREAD_SUSPENDED,
-                                         (void *)(word)THREAD_SYSTEM_ID(p));
-                                /* Note: thread id might be truncated.  */
-                    break;
-                default:
-                    ABORT_ARG1("pthread_kill failed at suspend",
-                               ": errcode= %d", result);
-              }
-#           endif
+            /* The synchronization between GC_dirty (based on         */
+            /* test-and-set) and the signal-based thread suspension   */
+            /* is performed in GC_stop_world because                  */
+            /* GC_release_dirty_lock cannot be called before          */
+            /* acknowledging the thread is really suspended.          */
+            result = RAISE_SIGNAL(p, GC_sig_suspend);
+            switch(result) {
+              case ESRCH:
+                  /* Not really there anymore.  Possible? */
+                  n_live_threads--;
+                  break;
+              case 0:
+                  if (GC_on_thread_event)
+                    GC_on_thread_event(GC_EVENT_THREAD_SUSPENDED,
+                                       (void *)(word)THREAD_SYSTEM_ID(p));
+                              /* Note: thread id might be truncated.  */
+                  break;
+              default:
+                  ABORT_ARG1("pthread_kill failed at suspend",
+                             ": errcode= %d", result);
+            }
         }
       }
     }
@@ -894,7 +869,7 @@ STATIC int GC_suspend_all(void)
 
 GC_INNER void GC_stop_world(void)
 {
-# if !defined(GC_OPENBSD_UTHREADS) && !defined(NACL)
+# if !defined(NACL)
     int n_live_threads;
 # endif
   GC_ASSERT(I_HOLD_LOCK());
@@ -916,7 +891,7 @@ GC_INNER void GC_stop_world(void)
     }
 # endif /* PARALLEL_MARK */
 
-# if defined(GC_OPENBSD_UTHREADS) || defined(NACL)
+# if defined(NACL)
     (void)GC_suspend_all();
 # else
     AO_store(&GC_stop_count,
@@ -1110,50 +1085,39 @@ GC_INNER void GC_stop_world(void)
     int i;
     pthread_t self = pthread_self();
     GC_thread p;
-#   ifndef GC_OPENBSD_UTHREADS
-      int result;
-#   endif
+    int result;
 
     for (i = 0; i < THREAD_TABLE_SZ; i++) {
       for (p = GC_threads[i]; p != NULL; p = p -> next) {
         if (!THREAD_EQUAL(p -> id, self)) {
           if ((p -> flags & FINISHED) != 0) continue;
           if (p -> thread_blocked) continue;
-#         ifndef GC_OPENBSD_UTHREADS
-#           ifdef GC_ENABLE_SUSPEND_THREAD
-              if (p -> suspended_ext) continue;
-#           endif
-            if (GC_retry_signals
-                && AO_load(&p->stop_info.last_stop_count)
-                    == (AO_t)((word)GC_stop_count | THREAD_RESTARTED))
-              continue; /* The thread has been restarted. */
-            n_live_threads++;
+#         ifdef GC_ENABLE_SUSPEND_THREAD
+            if (p -> suspended_ext) continue;
 #         endif
+          if (GC_retry_signals
+              && AO_load(&p->stop_info.last_stop_count)
+                  == (AO_t)((word)GC_stop_count | THREAD_RESTARTED))
+            continue; /* The thread has been restarted. */
+          n_live_threads++;
 #         ifdef DEBUG_THREADS
             GC_log_printf("Sending restart signal to %p\n", (void *)p->id);
 #         endif
-#         ifdef GC_OPENBSD_UTHREADS
-            if (pthread_resume_np(p -> id) != 0)
-              ABORT("pthread_resume_np failed");
+          result = RAISE_SIGNAL(p, GC_sig_thr_restart);
+          switch(result) {
+          case ESRCH:
+            /* Not really there anymore.  Possible?   */
+            n_live_threads--;
+            break;
+          case 0:
             if (GC_on_thread_event)
-              GC_on_thread_event(GC_EVENT_THREAD_UNSUSPENDED, (void *)p->id);
-#         else
-            result = RAISE_SIGNAL(p, GC_sig_thr_restart);
-            switch(result) {
-            case ESRCH:
-              /* Not really there anymore.  Possible?   */
-              n_live_threads--;
-              break;
-            case 0:
-              if (GC_on_thread_event)
-                GC_on_thread_event(GC_EVENT_THREAD_UNSUSPENDED,
-                                   (void *)(word)THREAD_SYSTEM_ID(p));
-              break;
-            default:
-              ABORT_ARG1("pthread_kill failed at resume",
-                         ": errcode= %d", result);
-            }
-#         endif
+              GC_on_thread_event(GC_EVENT_THREAD_UNSUSPENDED,
+                                 (void *)(word)THREAD_SYSTEM_ID(p));
+            break;
+          default:
+            ABORT_ARG1("pthread_kill failed at resume",
+                       ": errcode= %d", result);
+          }
         }
       }
     }
@@ -1172,24 +1136,18 @@ GC_INNER void GC_start_world(void)
 #   ifdef DEBUG_THREADS
       GC_log_printf("World starting\n");
 #   endif
-#   ifndef GC_OPENBSD_UTHREADS
-      AO_store_release(&GC_world_is_stopped, FALSE);
-                    /* The updated value should now be visible to the   */
-                    /* signal handler (note that pthread_kill is not on */
-                    /* the list of functions which synchronize memory). */
-#   endif
+    AO_store_release(&GC_world_is_stopped, FALSE);
+                  /* The updated value should now be visible to the   */
+                  /* signal handler (note that pthread_kill is not on */
+                  /* the list of functions which synchronize memory). */
     n_live_threads = GC_restart_all();
-#   ifndef GC_OPENBSD_UTHREADS
-      if (GC_retry_signals)
-        n_live_threads = resend_lost_signals(n_live_threads, GC_restart_all);
-#     ifdef GC_NETBSD_THREADS_WORKAROUND
-        suspend_restart_barrier(n_live_threads);
-#     else
-        if (GC_retry_signals)
-          suspend_restart_barrier(n_live_threads);
-#     endif
+    if (GC_retry_signals)
+      n_live_threads = resend_lost_signals(n_live_threads, GC_restart_all);
+#   ifdef GC_NETBSD_THREADS_WORKAROUND
+      suspend_restart_barrier(n_live_threads);
 #   else
-      (void)n_live_threads;
+      if (GC_retry_signals)
+        suspend_restart_barrier(n_live_threads);
 #   endif
 #   ifdef DEBUG_THREADS
       GC_log_printf("World started\n");
@@ -1207,7 +1165,7 @@ GC_INNER void GC_start_world(void)
 
 GC_INNER void GC_stop_init(void)
 {
-# if !defined(GC_OPENBSD_UTHREADS) && !defined(NACL)
+# if !defined(NACL)
     struct sigaction act;
     char *str;
 
@@ -1283,7 +1241,7 @@ GC_INNER void GC_stop_init(void)
       /* Explicitly unblock the signals once before new threads creation. */
       GC_unblock_gc_signals();
 #   endif
-# endif /* !GC_OPENBSD_UTHREADS && !NACL */
+# endif /* !NACL */
 }
 
 #endif /* GC_PTHREADS && !GC_DARWIN_THREADS && !GC_WIN32_THREADS */

--- a/pthread_support.c
+++ b/pthread_support.c
@@ -443,8 +443,7 @@ GC_INNER void GC_start_mark_threads_inner(void)
       if (sigfillset(&set) != 0)
         ABORT("sigfillset failed");
 
-#     if !defined(GC_DARWIN_THREADS) && !defined(GC_OPENBSD_UTHREADS) \
-         && !defined(NACL)
+#     if !defined(GC_DARWIN_THREADS) && !defined(NACL)
         /* These are used by GC to stop and restart the world.  */
         if (sigdelset(&set, GC_get_suspend_signal()) != 0
             || sigdelset(&set, GC_get_thr_restart_signal()) != 0)

--- a/tests/initsecondarythread.c
+++ b/tests/initsecondarythread.c
@@ -73,7 +73,7 @@ int main(void)
     DWORD thread_id;
 # endif
 # if !(defined(BEOS) || defined(MSWIN32) || defined(MSWINCE) \
-       || defined(CYGWIN32) || defined(GC_OPENBSD_UTHREADS) \
+       || defined(CYGWIN32) \
        || (defined(DARWIN) && !defined(NO_PTHREAD_GET_STACKADDR_NP)) \
        || ((defined(FREEBSD) || defined(LINUX) || defined(NETBSD) \
             || defined(HOST_ANDROID)) && !defined(NO_PTHREAD_GETATTR_NP) \

--- a/tests/test.c
+++ b/tests/test.c
@@ -632,8 +632,8 @@ void check_marks_int_list(sexpr x)
         FAIL;
       }
 #     if defined(GC_ENABLE_SUSPEND_THREAD) && !defined(GC_DARWIN_THREADS) \
-         && !defined(GC_OPENBSD_UTHREADS) && !defined(GC_WIN32_THREADS) \
-         && !defined(NACL) && !defined(GC_OSF1_THREADS)
+         && !defined(GC_WIN32_THREADS) && !defined(NACL) \
+         && !defined(GC_OSF1_THREADS)
         if (GC_is_thread_suspended(t)) {
           GC_printf("Running thread should be not suspended\n");
           FAIL;


### PR DESCRIPTION
This pull request updates OpenBSD support and removes some outdated workarounds. This is based on the recent OpenBSD update in the ports tree (https://github.com/openbsd/ports/commit/249e6c0862f3530709a3d5a91db7fbf392530aff) with the following differences:

I've completely removed support for OpenBSD uthreads. OpenBSD user-land threading model was replaced by kernel supported threads (rthreads) about 9 years ago so it seems like keeping this dead code around is not useful anymore.

When threading is disabled by configure, USERSTACK is not usable on OpenBSD due to the random sized PROT_NONE stack gap. So I removed its use and will always use HEURISTIC2. when threading is disabled on OpenBSD.

The changes in this pull request have been tested on the following OpenBSD architectures:
 i386/amd64/sparc64/aarch64/powerpc/powerpc64/mips64/alpha
 
 After is is merged, I will work on incorporating these changes into the master branch as well.