### PR TITLE
Update OpenBSD Support

### DIFF
--- a/dyn_load.c
+++ b/dyn_load.c
@@ -81,13 +81,6 @@ STATIC GC_has_static_roots_func GC_has_static_roots = 0;
 #   define ELFSIZE ARCH_ELFSIZE
 #endif
 
-#if defined(OPENBSD)
-# include <sys/param.h>
-# if (OpenBSD >= 200519) && !defined(HAVE_DL_ITERATE_PHDR)
-#   define HAVE_DL_ITERATE_PHDR
-# endif
-#endif /* OPENBSD */
-
 #if defined(SCO_ELF) || defined(DGUX) || defined(HURD) || defined(NACL) \
     || (defined(__ELF__) && (defined(LINUX) || defined(FREEBSD) \
                              || defined(NETBSD) || defined(OPENBSD)))
@@ -149,8 +142,10 @@ STATIC GC_has_static_roots_func GC_has_static_roots = 0;
 #    elif defined(NETBSD) || defined(OPENBSD)
 #      if ELFSIZE == 32
 #        define ElfW(type) Elf32_##type
-#      else
+#      elif ELFSIZE == 64
 #        define ElfW(type) Elf64_##type
+#      else
+#        error Missing required ELFSIZE define
 #      endif
 #    else
 #      if !defined(ELF_CLASS) || ELF_CLASS == ELFCLASS32

--- a/include/gc_config_macros.h
+++ b/include/gc_config_macros.h
@@ -84,13 +84,13 @@
 #elif defined(GC_THREADS)
 # if defined(__linux__)
 #   define GC_LINUX_THREADS
+# elif defined(__OpenBSD__)
+#   define GC_OPENBSD_THREADS
 # elif defined(_PA_RISC1_1) || defined(_PA_RISC2_0) || defined(hppa) \
        || defined(__HPPA) || (defined(__ia64) && defined(_HPUX_SOURCE))
 #   define GC_HPUX_THREADS
 # elif defined(__HAIKU__)
 #   define GC_HAIKU_THREADS
-# elif defined(__OpenBSD__)
-#   define GC_OPENBSD_THREADS
 # elif defined(__DragonFly__) || defined(__FreeBSD_kernel__) \
        || (defined(__FreeBSD__) && !defined(SN_TARGET_ORBIS))
 #   define GC_FREEBSD_THREADS

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -2795,9 +2795,7 @@ GC_INNER void *GC_store_debug_info_inner(void *p, word sz, const char *str,
 #     define SIG_SUSPEND SIGPWR
 #   endif
 # elif defined(GC_OPENBSD_THREADS)
-#   ifndef GC_OPENBSD_UTHREADS
-#     define SIG_SUSPEND SIGXFSZ
-#   endif
+#   define SIG_SUSPEND SIGXFSZ
 # elif defined(_SIGRTMIN) && !defined(CPPCHECK)
 #   define SIG_SUSPEND _SIGRTMIN + 6
 # else

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -2886,6 +2886,8 @@ EXTERN_C_BEGIN
     /* The kernel may do a somewhat better job merging mappings etc.    */
     /* with anonymous mappings.                                         */
 #   define USE_MMAP_ANON
+#elif defined(OPENBSD) && defined(USE_MMAP)
+#   define USE_MMAP_ANON
 #endif
 
 #if defined(GC_LINUX_THREADS) && defined(REDIRECT_MALLOC) \

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -3097,17 +3097,6 @@ EXTERN_C_BEGIN
 # define GC_NETBSD_THREADS_WORKAROUND
 #endif
 
-#ifdef GC_OPENBSD_THREADS
-  EXTERN_C_END
-# include <sys/param.h>
-  EXTERN_C_BEGIN
-  /* Prior to 5.2 release, OpenBSD had user threads and required        */
-  /* special handling.                                                  */
-# if OpenBSD < 201211
-#   define GC_OPENBSD_UTHREADS 1
-# endif
-#endif /* GC_OPENBSD_THREADS */
-
 #if defined(SVR4) || defined(LINUX) || defined(IRIX5) || defined(HPUX) \
     || defined(OPENBSD) || defined(NETBSD) || defined(FREEBSD) \
     || defined(DGUX) || defined(BSD) || defined(HAIKU) || defined(HURD) \

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1056,7 +1056,12 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
-#     define ALIGNMENT 4
+#     if defined(__powerpc64__)
+#       define ALIGNMENT 8
+#       define CPP_WORDSZ 64
+#     else
+#       define ALIGNMENT 4
+#     endif
 #     ifndef GC_OPENBSD_THREADS
 #       define HEURISTIC2
 #     endif

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1994,7 +1994,6 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef OPENBSD
 #       define OS_TYPE "OPENBSD"
-#       define ELF_CLASS ELFCLASS64
 #       ifndef GC_OPENBSD_THREADS
 #         define HEURISTIC2
 #       endif
@@ -2303,7 +2302,6 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
-#     define ELF_CLASS ELFCLASS64
 #     ifndef GC_OPENBSD_THREADS
 #       define HEURISTIC2
 #     endif
@@ -2580,7 +2578,6 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef OPENBSD
 #       define OS_TYPE "OPENBSD"
-#       define ELF_CLASS ELFCLASS64
 #       ifndef GC_OPENBSD_THREADS
 #         define HEURISTIC2
 #       endif

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1058,17 +1058,7 @@ EXTERN_C_BEGIN
 #     define OS_TYPE "OPENBSD"
 #     define ALIGNMENT 4
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-        /* USRSTACK is defined in <machine/vmparam.h> but that is       */
-        /* protected by _KERNEL in <uvm/uvm_param.h> file.              */
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -1283,15 +1273,7 @@ EXTERN_C_BEGIN
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -1607,15 +1589,7 @@ EXTERN_C_BEGIN
 #   ifdef OPENBSD
 #       define OS_TYPE "OPENBSD"
 #       ifndef GC_OPENBSD_THREADS
-          EXTERN_C_END
-#         include <sys/param.h>
-#         include <uvm/uvm_extern.h>
-          EXTERN_C_BEGIN
-#         ifdef USRSTACK
-#           define STACKBOTTOM ((ptr_t)USRSTACK)
-#         else
-#           define HEURISTIC2
-#         endif
+#         define HEURISTIC2
 #       endif
         extern int __data_start[];
 #       define DATASTART ((ptr_t)__data_start)
@@ -1856,15 +1830,7 @@ EXTERN_C_BEGIN
 #     define CPP_WORDSZ 64 /* all OpenBSD/mips platforms are 64-bit */
 #     define ALIGNMENT 8
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -2002,15 +1968,7 @@ EXTERN_C_BEGIN
 #  ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -2038,15 +1996,7 @@ EXTERN_C_BEGIN
 #       define OS_TYPE "OPENBSD"
 #       define ELF_CLASS ELFCLASS64
 #       ifndef GC_OPENBSD_THREADS
-          EXTERN_C_END
-#         include <sys/param.h>
-#         include <uvm/uvm_extern.h>
-          EXTERN_C_BEGIN
-#         ifdef USRSTACK
-#           define STACKBOTTOM ((ptr_t)USRSTACK)
-#         else
-#           define HEURISTIC2
-#         endif
+#         define HEURISTIC2
 #       endif
         extern int __data_start[];
 #       define DATASTART ((ptr_t)__data_start)
@@ -2355,15 +2305,7 @@ EXTERN_C_BEGIN
 #     define OS_TYPE "OPENBSD"
 #     define ELF_CLASS ELFCLASS64
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -2486,15 +2428,7 @@ EXTERN_C_BEGIN
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -2575,15 +2509,7 @@ EXTERN_C_BEGIN
 #   ifdef OPENBSD
 #     define OS_TYPE "OPENBSD"
 #     ifndef GC_OPENBSD_THREADS
-        EXTERN_C_END
-#       include <sys/param.h>
-#       include <uvm/uvm_extern.h>
-        EXTERN_C_BEGIN
-#       ifdef USRSTACK
-#         define STACKBOTTOM ((ptr_t)USRSTACK)
-#       else
-#         define HEURISTIC2
-#       endif
+#       define HEURISTIC2
 #     endif
       extern int __data_start[];
 #     define DATASTART ((ptr_t)__data_start)
@@ -2656,15 +2582,7 @@ EXTERN_C_BEGIN
 #       define OS_TYPE "OPENBSD"
 #       define ELF_CLASS ELFCLASS64
 #       ifndef GC_OPENBSD_THREADS
-          EXTERN_C_END
-#         include <sys/param.h>
-#         include <uvm/uvm_extern.h>
-          EXTERN_C_BEGIN
-#         ifdef USRSTACK
-#           define STACKBOTTOM ((ptr_t)USRSTACK)
-#         else
-#           define HEURISTIC2
-#         endif
+#         define HEURISTIC2
 #       endif
         extern int __data_start[];
         extern int _end[];

--- a/include/private/pthread_stop_world.h
+++ b/include/private/pthread_stop_world.h
@@ -21,8 +21,8 @@
 EXTERN_C_BEGIN
 
 struct thread_stop_info {
-#   if !defined(GC_OPENBSD_UTHREADS) && !defined(NACL) \
-       && !defined(SN_TARGET_ORBIS) && !defined(SN_TARGET_PSP2)
+#   if !defined(NACL) && !defined(SN_TARGET_ORBIS) \
+       && !defined(SN_TARGET_PSP2)
       volatile AO_t last_stop_count;
                         /* The value of GC_stop_count when the thread   */
                         /* last successfully handled a suspend signal.  */

--- a/include/private/pthread_support.h
+++ b/include/private/pthread_support.h
@@ -67,7 +67,7 @@ typedef struct GC_Thread_Rep {
     struct thread_stop_info stop_info;
 
 #   if defined(GC_ENABLE_SUSPEND_THREAD) && !defined(GC_DARWIN_THREADS) \
-        && !defined(GC_OPENBSD_UTHREADS) && !defined(NACL)
+        && !defined(NACL)
       volatile AO_t suspended_ext;  /* Thread was suspended externally. */
 #   endif
 

--- a/misc.c
+++ b/misc.c
@@ -611,8 +611,8 @@ GC_API void GC_CALL GC_get_heap_usage_safe(GC_word *pheap_size,
 
 #endif /* !GC_GET_HEAP_USAGE_NOT_NEEDED */
 
-#if defined(GC_DARWIN_THREADS) || defined(GC_OPENBSD_UTHREADS) \
-    || defined(GC_WIN32_THREADS) || (defined(NACL) && defined(THREADS))
+#if defined(GC_DARWIN_THREADS) || defined(GC_WIN32_THREADS) \
+    || (defined(NACL) && defined(THREADS))
   /* GC does not use signals to suspend and restart threads.    */
   GC_API void GC_CALL GC_set_suspend_signal(int sig GC_ATTR_UNUSED)
   {

--- a/os_dep.c
+++ b/os_dep.c
@@ -516,64 +516,9 @@ GC_INNER char * GC_get_maps(void)
   static struct sigaction old_segv_act;
   STATIC JMP_BUF GC_jmp_buf_openbsd;
 
-# ifdef THREADS
-#   include <sys/syscall.h>
-    EXTERN_C_BEGIN
-    extern sigset_t __syscall(quad_t, ...);
-    EXTERN_C_END
-# endif
-
-  /* Don't use GC_find_limit() because siglongjmp() outside of the      */
-  /* signal handler by-passes our userland pthreads lib, leaving        */
-  /* SIGSEGV and SIGPROF masked.  Instead, use this custom one that     */
-  /* works-around the issues.                                           */
-
   STATIC void GC_fault_handler_openbsd(int sig GC_ATTR_UNUSED)
   {
      LONGJMP(GC_jmp_buf_openbsd, 1);
-  }
-
-  /* Return the first non-addressable location > p or bound.    */
-  /* Requires the allocation lock.                              */
-  STATIC ptr_t GC_find_limit_openbsd(ptr_t p, ptr_t bound)
-  {
-    static volatile ptr_t result;
-             /* Safer if static, since otherwise it may not be  */
-             /* preserved across the longjmp.  Can safely be    */
-             /* static since it's only called with the          */
-             /* allocation lock held.                           */
-
-    struct sigaction act;
-    word pgsz = (word)sysconf(_SC_PAGESIZE);
-
-    GC_ASSERT((word)bound >= pgsz);
-    GC_ASSERT(I_HOLD_LOCK());
-
-    act.sa_handler = GC_fault_handler_openbsd;
-    sigemptyset(&act.sa_mask);
-    act.sa_flags = SA_NODEFER | SA_RESTART;
-    /* act.sa_restorer is deprecated and should not be initialized. */
-    sigaction(SIGSEGV, &act, &old_segv_act);
-
-    if (SETJMP(GC_jmp_buf_openbsd) == 0) {
-      result = (ptr_t)((word)p & ~(pgsz-1));
-      for (;;) {
-        if ((word)result >= (word)bound - pgsz) {
-          result = bound;
-          break;
-        }
-        result += pgsz; /* no overflow expected */
-        GC_noop1((word)(*result));
-      }
-    }
-
-#   ifdef THREADS
-      /* Due to the siglongjump we need to manually unmask SIGPROF.     */
-      __syscall(SYS_sigprocmask, SIG_UNBLOCK, sigmask(SIGPROF));
-#   endif
-
-    sigaction(SIGSEGV, &old_segv_act, 0);
-    return(result);
   }
 
   static volatile int firstpass;
@@ -2042,7 +1987,8 @@ void GC_register_data_segments(void)
     ABORT_ARG2("Wrong DATASTART/END pair",
                ": %p .. %p", (void *)region_start, (void *)DATAEND);
   for (;;) {
-    ptr_t region_end = GC_find_limit_openbsd(region_start, DATAEND);
+    ptr_t region_end = GC_find_limit_with_bound(region_start, TRUE,
+                                                DATAEND);
 
     GC_add_roots_inner(region_start, region_end, FALSE);
     if ((word)region_end >= (word)DATAEND)
@@ -3344,8 +3290,7 @@ GC_API GC_push_other_roots_proc GC_CALL GC_get_push_other_roots(void)
       act.sa_flags = SA_RESTART | SA_SIGINFO;
       act.sa_sigaction = GC_write_fault_handler;
       (void)sigemptyset(&act.sa_mask);
-#     if defined(THREADS) && !defined(GC_OPENBSD_UTHREADS) \
-         && !defined(GC_WIN32_THREADS) && !defined(NACL)
+#     if defined(THREADS) && !defined(GC_WIN32_THREADS) && !defined(NACL)
         /* Arrange to postpone the signal while we are in a write fault */
         /* handler.  This effectively makes the handler atomic w.r.t.   */
         /* stopping the world for GC.                                   */

--- a/pthread_support.c
+++ b/pthread_support.c
@@ -481,8 +481,7 @@ GC_INNER void GC_start_mark_threads_inner(void)
       if (sigfillset(&set) != 0)
         ABORT("sigfillset failed");
 
-#     if !defined(GC_DARWIN_THREADS) && !defined(GC_OPENBSD_UTHREADS) \
-         && !defined(NACL)
+#     if !defined(GC_DARWIN_THREADS) && !defined(NACL)
         /* These are used by GC to stop and restart the world.  */
         if (sigdelset(&set, GC_get_suspend_signal()) != 0
             || sigdelset(&set, GC_get_thr_restart_signal()) != 0)

--- a/tests/initsecondarythread.c
+++ b/tests/initsecondarythread.c
@@ -73,7 +73,7 @@ int main(void)
     DWORD thread_id;
 # endif
 # if !(defined(BEOS) || defined(MSWIN32) || defined(MSWINCE) \
-       || defined(CYGWIN32) || defined(GC_OPENBSD_UTHREADS) \
+       || defined(CYGWIN32) \
        || (defined(DARWIN) && !defined(NO_PTHREAD_GET_STACKADDR_NP)) \
        || ((defined(FREEBSD) || defined(LINUX) || defined(NETBSD) \
             || defined(HOST_ANDROID)) && !defined(NO_PTHREAD_GETATTR_NP) \

--- a/tests/test.c
+++ b/tests/test.c
@@ -627,8 +627,8 @@ void check_marks_int_list(sexpr x)
         FAIL;
       }
 #     if defined(GC_ENABLE_SUSPEND_THREAD) && !defined(GC_DARWIN_THREADS) \
-         && !defined(GC_OPENBSD_UTHREADS) && !defined(GC_WIN32_THREADS) \
-         && !defined(NACL) && !defined(GC_OSF1_THREADS)
+         && !defined(GC_WIN32_THREADS) && !defined(NACL) \
+         && !defined(GC_OSF1_THREADS)
         if (GC_is_thread_suspended(t)) {
           GC_printf("Running thread should be not suspended\n");
           FAIL;


### PR DESCRIPTION
This pull request updates OpenBSD support and removes some outdated workarounds. This is based on the recent OpenBSD update in the ports tree (openbsd/ports@249e6c0) with the following differences:

I've completely removed support for OpenBSD uthreads. OpenBSD user-land threading model was replaced by kernel supported threads (rthreads) about 9 years ago so it seems like keeping this dead code around is not useful anymore.

When threading is disabled by configure, USERSTACK is not usable on OpenBSD due to the random sized PROT_NONE stack gap. So I removed its use and will always use HEURISTIC2. when threading is disabled on OpenBSD.