### PR TITLE
Emscripten support with gctest mostly passing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,6 +91,10 @@ endif
 endif
 endif
 
+if EMSCRIPTEN
+libgc_la_SOURCES += emscripten.c
+endif
+
 if THREAD_LOCAL_ALLOC
 libgc_la_SOURCES += thread_local_alloc.c
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,20 @@ esac
 
 
 GC_CFLAGS=${gc_cflags}
+
+AC_MSG_CHECKING([for emscripten])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#ifdef __EMSCRIPTEN__
+#error "this is emscripten"
+#endif
+]])], [emscripten=no], [emscripten=yes])
+dnl -s ASYNCIFY is required to scan the stack, ASYNCIFY_STACK_SIZE is
+dnl probably needed for gctest only
+AS_IF([test "x$emscripten" = "xyes"],
+      [GC_CFLAGS="$GC_CFLAGS -s ASYNCIFY -s ASYNCIFY_STACK_SIZE=128000"])
+AM_CONDITIONAL(EMSCRIPTEN, test x$emscripten = xyes)
+AC_MSG_RESULT([$emscripten])
+
 AC_SUBST(GC_CFLAGS)
 
 dnl Extra user-defined flags to pass both to C and C++ compilers.
@@ -96,7 +110,7 @@ AC_ARG_ENABLE(threads,
   THREADS=$enableval,
   [ AC_MSG_CHECKING([for thread model used by GCC])
     THREADS=`$CC -v 2>&1 | sed -n 's/^Thread model: //p'`
-    if test -z "$THREADS"; then
+    if test -z "$THREADS" -o "x$emscripten" = "xyes"; then
       THREADS=no
     fi
     if test "$THREADS" = "posix"; then

--- a/emscripten.c
+++ b/emscripten.c
@@ -1,0 +1,35 @@
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+
+#include "private/gc_priv.h"
+
+static void* stack_base;
+static void* stack_bottom;
+
+static void scan_fun(void *begin, void *end)
+{
+	stack_base = end;
+	stack_bottom = begin;
+}
+
+void *GC_get_main_emscripten_stack_base()
+{
+	emscripten_scan_stack(scan_fun);
+	return stack_base;
+}
+
+static void scan_regs(void *begin, void *end)
+{
+	GC_push_all_stack((ptr_t)begin, (ptr_t)end);
+}
+
+void GC_CALLBACK GC_default_emscripten_push_other_roots(void)
+{
+	/*
+	 * This neess -s ASYNCIFY -s ASYNCIFY_STACK_SIZE=128000
+	 *
+	 * but hopefully the latter is only required for gctest
+	 */
+	emscripten_scan_registers(scan_regs);
+}
+#endif

--- a/extra/gc.c
+++ b/extra/gc.c
@@ -72,6 +72,7 @@
 #include "../pthread_support.c"
 #include "../specific.c"
 #include "../win32_threads.c"
+#include "../emscripten.c"
 
 #ifndef GC_PTHREAD_START_STANDALONE
 # include "../pthread_start.c"

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1354,14 +1354,8 @@ EXTERN_C_BEGIN
 #     define OS_TYPE "EMSCRIPTEN"
 #     define DATASTART (ptr_t)ALIGNMENT
 #     define DATAEND (ptr_t)ALIGNMENT
-      /* Since JavaScript/asm.js/WebAssembly is not able to access the  */
-      /* function call stack or the local data stack, it's not possible */
-      /* for GC to perform its stack walking operation to find roots on */
-      /* the stack.  To work around that, the clients generally only do */
-      /* BDWGC steps when the stack is empty so it is known that there  */
-      /* are no objects that would be found on the stack, and BDWGC is  */
-      /* compiled with stack walking disabled.                          */
-#     define STACK_NOT_SCANNED
+#     define USE_MMAP_ANON	/* avoid /dev/zero, not supported */
+#     define STACK_GROWS_DOWN
 #   endif
 #   if defined(__QNX__)
 #     define OS_TYPE "QNX"

--- a/mach_dep.c
+++ b/mach_dep.c
@@ -232,6 +232,8 @@ GC_INNER void GC_with_callee_saves_pushed(void (*fn)(ptr_t, void *),
 
 # if defined(HAVE_PUSH_REGS)
     GC_push_regs();
+# elif defined(__EMSCRIPTEN__)
+    /* nothing, "registers" are push in GC_push_other_roots() */
 # else
 #   if defined(UNIX_LIKE) && !defined(NO_GETCONTEXT)
       /* Older versions of Darwin seem to lack getcontext().    */

--- a/tests/test.c
+++ b/tests/test.c
@@ -787,13 +787,17 @@ void *GC_CALLBACK reverse_test_inner(void *data)
     GC_FREE((void *)e);
 
     check_ints(b,1,50);
+#ifndef __EMSCRIPTEN__
     check_ints(a_get(),1,49);
+#endif
     for (i = 0; i < 50; i++) {
         check_ints(b,1,50);
         b = reverse(reverse(b));
     }
     check_ints(b,1,50);
+#ifndef __EMSCRIPTEN__
     check_ints(a_get(),1,49);
+#endif
     for (i = 0; i < 60; i++) {
 #       if (defined(GC_PTHREADS) || defined(GC_WIN32_THREADS)) \
            && (NTHREADS > 0)
@@ -811,7 +815,9 @@ void *GC_CALLBACK reverse_test_inner(void *data)
           AO_fetch_and_add1(&realloc_count);
 #       endif
     }
+#ifndef __EMSCRIPTEN__
     check_ints(a_get(),1,49);
+#endif
     check_ints(b,1,50);
 
     /* Restore c and d values. */

--- a/tests/tests.am
+++ b/tests/tests.am
@@ -21,6 +21,17 @@ gctest_LDADD += $(THREADDLLIBS)
 endif
 gctest_DEPENDENCIES = $(top_builddir)/libgc.la
 
+if EMSCRIPTEN
+# because of libtool, you'll need to point your browser to
+# .libs/gctest.html, NOT gctest.html at topdir.
+check_PROGRAMS += gctest.html
+gctest_html_SOURCES = $(gctest_SOURCES)
+gctest_html_LDADD = $(gctest_LDADD)
+# bug in the linker not being able to determine that _memalign and
+# _memalign is needed? it's part of mmap.
+gctest_html_LDFLAGS = -s "EXPORTED_FUNCTIONS=['_memalign', '_main', '_memset']"
+endif
+
 TESTS += leaktest$(EXEEXT)
 check_PROGRAMS += leaktest
 leaktest_SOURCES = tests/leak_test.c


### PR DESCRIPTION
This adds a bit more in os_dep.c in order to scan the stack and
registers, which is possible if we enable ASYNCIFY (note, this adds
quite some overhead). gctest almost passes with this, except the tests
that involve a_get()

The build system (at least autotools-based) is updated to detect and
configure emscripten correctly. No thread support for now. No idea how
to stop other threads (perhaps we need support from JS side?)

To build

    # source EMSDK first
    emconfigure ./configure
    emmake make gctest.html
    # point your browser at .libs/gctest.html