### PR TITLE
Include <alloca.h> when using alloca on AIX

### DIFF
--- a/dyn_load.c
+++ b/dyn_load.c
@@ -1207,7 +1207,7 @@ GC_INNER void GC_register_dynamic_libraries(void)
 #endif /* HPUX */
 
 #ifdef AIX
-# pragma alloca
+# include <alloca.h>
 # include <sys/ldr.h>
 # include <sys/errno.h>
   GC_INNER void GC_register_dynamic_libraries(void)


### PR DESCRIPTION
Using "#pragma alloca" only works with XLC, in order to enable alloca
calls. Including <alloca.h> works for both GCC and XLC

* dyn_load.c: Replace "#pragma alloca" by "#include <alloca.h>"