### PR TITLE
Replace SSH cloning with HTTPS cloning in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ Please note that the collector source repository does not contain configure
 and similar auto-generated files, thus the full procedure of autoconf-based
 build of `master` branch of the collector could look like:
 
-    git clone git://github.com/ivmai/bdwgc.git
+    git clone https://github.com/ivmai/bdwgc
     cd bdwgc
-    git clone git://github.com/ivmai/libatomic_ops.git
+    git clone https://github.com/ivmai/libatomic_ops
     ./autogen.sh
     ./configure
     make -j


### PR DESCRIPTION
Currently the readme gives a SSH url, which is unnecessary and will result in the following error on an unconfigured machine:
```
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```