### PR TITLE
GC_remove_roots now exists on all platforms (as a no-operation on some platforms).

### DIFF
--- a/mark_rts.c
+++ b/mark_rts.c
@@ -373,6 +373,9 @@ STATIC void GC_remove_tmp_roots(void)
     if (rebuild)
         GC_rebuild_root_index();
   }
+#else
+  GC_API void GC_CALL GC_remove_roots(void *, void *)
+  {}
 #endif /* !defined(MSWIN32) && !defined(MSWINCE) && !defined(CYGWIN32) */
 
 #ifdef USE_PROC_FOR_LIBRARIES


### PR DESCRIPTION
This allows applications to call `GC_remove_roots` without the specific test (and without keeping sync with the specific test).

Before:

```
#if ! defined (MSWIN32) && ! defined (MSWINCE) && ! defined (CYGWIN32)
    GC_remove_roots (my_arg_b, my_arg_e);
#endif
```

Now:

```
    GC_remove_roots (my_arg_b, my_arg_e);
```

The effect is the same (no-operation on Windows and Cygwin), but it is easier to write application code.