### PR TITLE
Allow users to know whether GC_remove_roots exists on their platforms.

### DIFF
--- a/include/gc/gc_config_macros.h
+++ b/include/gc/gc_config_macros.h
@@ -455,4 +455,10 @@
 
 #endif /* __cplusplus */
 
+#if defined(__CYGWIN32__) || defined(__CYGWIN__) || defined(_WIN32)
+# define GC_HAS_REMOVE_ROOTS 0
+#else
+# define GC_HAS_REMOVE_ROOTS 1
+#endif
+
 #endif

--- a/mark_rts.c
+++ b/mark_rts.c
@@ -338,6 +338,10 @@ STATIC void GC_remove_tmp_roots(void)
 }
 #endif
 
+#if (!defined(MSWIN32) && !defined(MSWINCE) && !defined(CYGWIN32)) != ! ! GC_HAS_REMOVE_ROOTS
+# error GC_HAS_REMOVE_ROOTS has not been defined correctly.
+#endif
+
 #if !defined(MSWIN32) && !defined(MSWINCE) && !defined(CYGWIN32)
   STATIC void GC_remove_roots_inner(ptr_t b, ptr_t e);
 


### PR DESCRIPTION
A new macro (GC_HAS_REMOVE_ROOTS) indicates (un)availability of `GC_remove_roots`.

Example of how users can now "portably" call `GC_remove_roots` (or not):

```
    #if GC_HAS_REMOVE_ROOTS
        GC_remove_roots(my_b, my_e);
    #endif
```

Once `GC_remove_roots` is implemented on remaining platforms (the difficult work),
we should update the definition of `GC_HAS_REMOVE_ROOTS` accordingly.