### PR TITLE
Fix undefined reference to "__data_start" on AArch64

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -2092,7 +2092,7 @@ EXTERN_C_BEGIN
 #     if defined(HOST_ANDROID)
 #       define SEARCH_FOR_DATA_START
 #     else
-        extern int __data_start[];
+        extern int __data_start[] __attribute__((__weak__));
 #       define DATASTART ((ptr_t)__data_start)
 #     endif
 #   endif


### PR DESCRIPTION
Related: #294