### PR TITLE
Fix configure with Clang 15 (implicit function declarations)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -834,12 +834,16 @@ AS_IF([test "$THREADS" = posix],
   [AC_MSG_CHECKING(for pthread_setname_np)
    old_CFLAGS="$CFLAGS"
    CFLAGS="$CFLAGS $CFLAGS_EXTRA -Werror"
-   AC_TRY_COMPILE([#include <pthread.h>],
+   AC_TRY_COMPILE([
+#define _GNU_SOURCE 1
+#include <pthread.h>],
                   [pthread_setname_np("thread-name")],
      [AC_MSG_RESULT([yes (w/o tid)])
       AC_DEFINE([HAVE_PTHREAD_SETNAME_NP_WITHOUT_TID], [1],
                 [Define to use 'pthread_setname_np(const char*)' function.])],
-     [AC_TRY_COMPILE([#include <pthread.h>],
+     [AC_TRY_COMPILE([
+#define _GNU_SOURCE 1
+#include <pthread.h>],
                      [pthread_setname_np(pthread_self(), "thread-name-%u", 0)],
        [AC_MSG_RESULT([yes (with tid and arg)])
         AC_DEFINE([HAVE_PTHREAD_SETNAME_NP_WITH_TID_AND_ARG], [1],


### PR DESCRIPTION
Clang 15 makes implicit function declarations an error by default which leads to configure falsely thinking `pthread_setname_np` is not present:
```
checking for pthread_setname_np... no
```

This fixes that issue and the following errors:
```
error: call to undeclared function 'pthread_setname_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
error: call to undeclared function 'pthread_setname_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
```

Signed-off-by: Sam James <sam@gentoo.org>