### PR TITLE
Allow passing in CFLAGS(_EXTRA)

### DIFF
--- a/Makefile.direct
+++ b/Makefile.direct
@@ -45,9 +45,9 @@ VPATH= $(srcdir)
 # Path to atomic_ops source.
 AO_SRC_DIR=$(srcdir)/libatomic_ops
 
-CFLAGS_EXTRA=
+CFLAGS_EXTRA+=
 # We need CFLAGS_FOR_PIC because we might be building a shared library.
-CFLAGS= -O -I$(srcdir)/include -I$(AO_SRC_DIR)/src \
+CFLAGS?= -O -I$(srcdir)/include -I$(AO_SRC_DIR)/src \
   -DALL_INTERIOR_POINTERS -DENABLE_DISCLAIM -DGC_ATOMIC_UNCOLLECTABLE \
   -DGC_GCJ_SUPPORT -DJAVA_FINALIZATION -DNO_EXECUTE_PERMISSION \
   -DUSE_MMAP -DUSE_MUNMAP $(CFLAGS_FOR_PIC) $(CFLAGS_EXTRA)


### PR DESCRIPTION
By using ?= we only set the CFLAGS variable in case it doesn't already have a value. This means it is now possible for someone to control the way bdwgc is compiled by feeding in the CFLAGS variable whereas previously one had to modify the Makefile.direct file. Further, since we consider the CFLAGS a reasonable default, the primary means of injecting control flags is by setting CFLAGS_EXTRA, where we now also allow passing in a value and the stuff in Makefile.direct is appended to that input.

This is very useful for using bdwgc from another repo, like you can just mirror bdwgc and then compile by feeding in all the compilation options as environment variables rather than having to first write them to the Makefile.direct file, which can be rather tricky to do programmatically. The normal mode of working is probably to CFLAGS_EXTRA, since that gets merged with the CFLAGS in Makefile.direct, but it also allows to directly set CFLAGS, thus overriding the default value of CFLAGS for total control.