### PR TITLE
Do not re-define EMSCRIPTEN when already defined, and take into account the system provided __EMSCRIPTEN__ variable.

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -478,8 +478,10 @@ EXTERN_C_BEGIN
 # if defined(SYMBIAN)
 #   define mach_type_known
 # endif
-# if defined(__EMSCRIPTEN__)
-#   define EMSCRIPTEN
+# if defined(__EMSCRIPTEN__) || defined(EMSCRIPTEN)
+#   ifndef EMSCRIPTEN
+#      define EMSCRIPTEN
+#   endif
 #   define I386
 #   define mach_type_known
 # endif


### PR DESCRIPTION
Remove definition of `EMSCRIPTEN` when building against WebAssembly/Emscripten, but instead use the toolchain built-in provided `__EMSCRIPTEN__`.

This fixes a build warning:

```
[1/23] Building C object CMakeFiles/initfromthreadtest.dir/tests/initfromthread.c.o
In file included from ../tests/initfromthread.c:61:
../include\private/gcconfig.h:482:12: warning: 'EMSCRIPTEN' macro redefined [-Wmacro-redefined]
#   define EMSCRIPTEN
           ^
<command line>:1:9: note: previous definition is here
#define EMSCRIPTEN 1
        ^
1 warning generated.
```
which occurs, because the Emscripten compiler does already generate the preprocessor define `EMSCRIPTEN` out of the box to all compiled source code files, when building without Emscripten's `-sSTRICT` command line option.

However that Emscripten behavior is deprecated, and the best practices behavior is to check against `__EMSCRIPTEN__` to detect whether compiling against Emscripten toolchain.