### PR TITLE
Don't attempt multithreaded Emscripten builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,10 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
                STRINGS "Debug" "Release" "RelWithDebInfo" "MinSizeRel")
 endif()
 
+if (enable_threads AND EMSCRIPTEN)
+  message(FATAL_ERROR "Multithreaded Bdwgc is not supported when targeting Emscripten, since WebAssembly does not currently support stopping the world synchronously. (see https://github.com/WebAssembly/design/issues/1459 about GC in WebAssembly). Please pass -Denable_threads=OFF to CMake to target singlethreaded WebAssembly.")
+endif()
+
 # Convert VER_INFO values to [SO]VERSION ones.
 if (BUILD_SHARED_LIBS)
   # cord:


### PR DESCRIPTION
If I understand correctly, Boehm requires being able to stop all managed threads before being able to collect. (via e.g. pthread_stop_world.c)? (are there any alternative solutions?)

WebAssembly/Web Workers do not currently/yet support synchronous stopping of all threads, so disallow building in multithreaded mode with Emscripten, and hint the user to build singlethreaded Bdwgc instead.

For future reference, attempting to build to WebAssembly with multithreading enabled currently fails with

```
[28/28] Linking C executable gctest.js
FAILED: gctest.js
cmd.exe /C "cd . && C:\emsdk\emscripten\main\emcc.bat -g  CMakeFiles/gctest.dir/tests/gctest.c.o -o gctest.js  libgc.a && cd ."
error: undefined symbol: pthread_kill (referenced by top-level compiled C/C++ code)
warning: Link with `-sLLD_REPORT_UNDEFINED` to get more information on undefined symbols
warning: To disable errors for undefined symbols use `-sERROR_ON_UNDEFINED_SYMBOLS=0`
warning: _pthread_kill may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
error: undefined symbol: sem_getvalue (referenced by top-level compiled C/C++ code)
warning: _sem_getvalue may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
error: undefined symbol: sigsuspend (referenced by top-level compiled C/C++ code)
warning: _sigsuspend may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
Error: Aborting compilation due to previous errors
emcc: error: 'C:/emsdk/node/14.18.2_64bit/bin/node.exe C:\emsdk\emscripten\main\src\compiler.js C:\Users\clb\AppData\Local\Temp\tmpkxx2t1u5.json' failed (returned 1)
ninja: build stopped: subcommand failed.
```