### PR TITLE
Simplify obtaining the stack base for Emscripten

### DIFF
--- a/os_dep.c
+++ b/os_dep.c
@@ -1242,19 +1242,11 @@ GC_INNER size_t GC_page_size = 0;
 # define GET_MAIN_STACKBASE_SPECIAL
 #elif defined(EMSCRIPTEN)
 # include <emscripten.h>
-
-  static void* emscripten_stack_base;
-
-  static void scan_stack_cb(void *begin, void *end)
-  {
-    (void)begin;
-    emscripten_stack_base = end;
-  }
+# include <emscripten/stack.h>
 
   ptr_t GC_get_main_stack_base(void)
   {
-    emscripten_scan_stack(scan_stack_cb);
-    return (ptr_t)emscripten_stack_base;
+    return (ptr_t)emscripten_stack_get_base();
   }
 # define GET_MAIN_STACKBASE_SPECIAL
 #elif !defined(AMIGA) && !defined(HAIKU) && !defined(OS2) \


### PR DESCRIPTION
Simplify obtaining the stack base for Emscripten by using the direct function `emscripten_stack_get_base()`, instead of the ASYNCIFY-only function `emscripten_scan_stack()`.