### PR TITLE
Disable targeting memory mapping features with WebAssembly

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1290,8 +1290,12 @@ EXTERN_C_BEGIN
 #     define OS_TYPE "EMSCRIPTEN"
 #     define DATASTART (ptr_t)ALIGNMENT
 #     define DATAEND (ptr_t)ALIGNMENT
-#     define USE_MMAP_ANON      /* avoid /dev/zero, not supported */
-#     undef USE_MUNMAP /* mmap(PROT_NONE) is unsupported, mprotect is no-op */
+      /* Emscripten does emulate mmap() and munmap(), but those     */
+      /* should never be used in bdwgc, since WebAssembly does not  */
+      /* natively support mmapping. sbrk() is always available, so  */
+      /* prefer to always use that instead.                         */
+#     undef USE_MMAP
+#     undef USE_MUNMAP
 #     if defined(GC_THREADS) && !defined(CPPCHECK)
 #       error No threads support yet
 #     endif


### PR DESCRIPTION
Disable targeting memory mapping features with WebAssembly, since it does not support them.

A previous commit https://github.com/ivmai/bdwgc/commit/1431bda1a87d66d669faab00aefe34349c54a56a#diff-e328c3468f5194bb02188ac05d707e86746440c5716394e4cb9054cd91d0865dR1351 added the `#define USE_MAP_ANON` flag when building with Emscripten.

It is unclear why that was done, and it is unfortunately the incorrect thing to do. That regressed Emscripten/WebAssembly tests to immediately abort at the line `GC_INIT();`, e.g.

```
C:\code\bdwgc\emcc> emcmake cmake .. -Denable_threads=OFF -Denable_tests=ON -G Ninja
...
C:\code\bdwgc\emcc> ninja
...
C:\code\bdwgc\emcc>node gctest.js
GC Warning: Out of memory - trying to allocate requested amount (32768 bytes)...
Insufficient memory for black list
program exited (with status: 1), but EXIT_RUNTIME is not set, so halting execution but not exiting the runtime or preventing further async execution (build with EXIT_RUNTIME=1, if you want a true shutdown)

C:\code\bdwgc\emcc>node middletest.js
GC Warning: Out of memory - trying to allocate requested amount (32768 bytes)...
Insufficient memory for black list
program exited (with status: 1), but EXIT_RUNTIME is not set, so halting execution but not exiting the runtime or preventing further async execution (build with EXIT_RUNTIME=1, if you want a true shutdown)
```

Emscripten does emulate `mmap()` and `munmap()` functions, but this emulation should not be used by production-quality codebases that are natively targeting Emscripten/WebAssembly. This mmap emulation in Emscripten is implemented via the virtual filesystem backend, and if there are no filesystem operations, the filesystem backend is not included in the build, which results in mmap() unconditionally failing in the test suite above:

https://github.com/emscripten-core/emscripten/blob/d659edc58b3b868d15d7b85b2a60e1260da8ebf0/src/library_syscall.js#L141-L142

The sbrk() infrastructure however is always present in Emscripten-compiled code, in all build modes, so this PR enforces that bdwgc is only attempted to be built against targeting side channel memory allocation via sbrk().

After this change, the above failures are resolved, and gctest/middletest do proceed further.

(they then fail with

```
C:\code\bdwgc\emcc>node gctest.js

C:\code\bdwgc\emcc\gctest.js:144
      throw ex;
      ^
Please compile your program with async support in order to use asynchronous operations like emscripten_scan_registers
(Use `node --trace-uncaught ...` to show where the exception was thrown)

C:\code\bdwgc\emcc>node middletest.js

C:\code\bdwgc\emcc\middletest.js:144
      throw ex;
      ^
Please compile your program with async support in order to use asynchronous operations like emscripten_scan_registers
(Use `node --trace-uncaught ...` to show where the exception was thrown)
```

I'll post separate PR to fix that)