### PR TITLE
Make Emscripten ASYNCIFY feature optional to target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,12 @@ option(disable_handle_fork "Prohibit installation of pthread_atfork() handlers" 
 option(install_headers "Install header and pkg-config metadata files" ON)
 option(with_libatomic_ops "Use an external libatomic_ops" OFF)
 option(without_libatomic_ops "Use atomic_ops.h in libatomic_ops/src" OFF)
+option(emscripten_asyncify "Use Emscripten's asyncify feature. Enable this if your program is targeting -sASYNCIFY, and disable otherwise" OFF)
+
+if (emscripten_asyncify)
+  add_definitions(-DEMSCRIPTEN_ASYNCIFY)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -sASYNCIFY -sASYNCIFY_STACK_SIZE=128000")
+endif()
 
 # Override the default build type to RelWithDebInfo (this instructs cmake to
 # pass -O2 -g -DNDEBUG options to the compiler by default).

--- a/os_dep.c
+++ b/os_dep.c
@@ -2803,7 +2803,7 @@ GC_INNER void GC_unmap_gap(ptr_t start1, size_t bytes1, ptr_t start2,
 /* thread stacks.                                               */
 #ifndef THREADS
 
-# ifdef EMSCRIPTEN
+# ifdef EMSCRIPTEN_ASYNCIFY
     static void scan_regs_cb(void *begin, void *end)
     {
       GC_push_all_stack((ptr_t)begin, (ptr_t)end);


### PR DESCRIPTION
The commit https://github.com/ivmai/bdwgc/commit/1431bda1a87d66d669faab00aefe34349c54a56a# unconditionally added a requirement that Emscripten's -sASYNCIFY feature would be used.

-sASYNCIFY is a relatively rarely used feature of Emscripten, most developers do not use it, and it does not scale well to moderate-to-large codebases. It incurs a heavy impact to code size and performance, and carries other correctness problems that developers must then adhere to regarding event loop message ordering.

The commit above regressed the non-ASYNCIFY use of bdwgc, which was to limit running GC between browser event loop ticks when there is no native code on the stack. (the commit simply removed the comment that explained this use case: https://github.com/ivmai/bdwgc/commit/1431bda1a87d66d669faab00aefe34349c54a56a#diff-e328c3468f5194bb02188ac05d707e86746440c5716394e4cb9054cd91d0865d and switched to assuming that everyone would use -sASYNCIFY).

To resolve both use cases, I am proposing to add a build option `EMSCRIPTEN_ASYNCIFY` to choose whether this feature is being targeted or not. This restores the previous use case for bdwgc.

Before this change (but with the mmap fix of #505), gctest.js and middletest.js would fail with error messages

```
C:\code\bdwgc\emcc>emcmake cmake .. -Denable_threads=OFF -Denable_tests=ON -G Ninja
...
C:\code\bdwgc\emcc>ninja
...
C:\code\bdwgc\emcc>node gctest.js

C:\code\bdwgc\emcc\gctest.js:144
      throw ex;
      ^
Please compile your program with async support in order to use asynchronous operations like emscripten_scan_registers
(Use `node --trace-uncaught ...` to show where the exception was thrown)

C:\code\bdwgc\emcc>node middletest.js

C:\code\bdwgc\emcc\middletest.js:144
      throw ex;
      ^
Please compile your program with async support in order to use asynchronous operations like emscripten_scan_registers
(Use `node --trace-uncaught ...` to show where the exception was thrown)
```
since the tests were being compiled without ASYNCIFY flags enabled.

After this change, building without `-Demscripten_asyncify` results in:

```
C:\code\bdwgc\emcc>emcmake cmake .. -Denable_threads=OFF -Dbuild_tests=ON -Demscripten_asyncify=OFF -G Ninja
...
C:\code\bdwgc\emcc>ninja
...
C:\code\bdwgc\emcc>node middletest.js
Final heap size is 65536

C:\code\bdwgc\emcc>node gctest.js
Test failed
Aborted(native code called abort())
C:\code\bdwgc\emcc\gctest.js:144
      throw ex;
      ^

RuntimeError: Aborted(native code called abort())
    at abort (C:\code\bdwgc\emcc\gctest.js:979:11)
    at _abort (C:\code\bdwgc\emcc\gctest.js:1311:7)
    at imports.<computed> (C:\code\bdwgc\emcc\gctest.js:1570:35)
    at run_one_test (<anonymous>:wasm-function[27]:0x5acf)
    at __original_main (<anonymous>:wasm-function[32]:0x6e21)
    at main (<anonymous>:wasm-function[33]:0x7027)
    at ret.<computed> (C:\code\bdwgc\emcc\gctest.js:1604:35)
    at Object.doRewind (C:\code\bdwgc\emcc\gctest.js:1683:16)
    at C:\code\bdwgc\emcc\gctest.js:1716:47
    at C:\code\bdwgc\emcc\gctest.js:1381:11
```
That is, `middletest` will then complete without crashing, but `gctest` does still fail.

Building with `emscripten_asyncify` enabled results in

```
C:\code\bdwgc\emcc_asyncify>emcmake cmake .. -Denable_threads=OFF -Dbuild_tests=ON -Demscripten_asyncify=ON -G Ninja
...
C:\code\bdwgc\emcc_asyncify>ninja
...
C:\code\bdwgc\emcc_asyncify>node gctest.js
Test failed
Aborted(native code called abort())
C:\code\bdwgc\emcc_asyncify\gctest.js:144
      throw ex;
      ^

RuntimeError: Aborted(native code called abort())
    at abort (C:\code\bdwgc\emcc_asyncify\gctest.js:979:11)
    at _abort (C:\code\bdwgc\emcc_asyncify\gctest.js:1311:7)
    at imports.<computed> (C:\code\bdwgc\emcc_asyncify\gctest.js:1570:35)
    at run_one_test (<anonymous>:wasm-function[27]:0x5acf)
    at __original_main (<anonymous>:wasm-function[32]:0x6e21)
    at main (<anonymous>:wasm-function[33]:0x7027)
    at ret.<computed> (C:\code\bdwgc\emcc_asyncify\gctest.js:1604:35)
    at Object.doRewind (C:\code\bdwgc\emcc_asyncify\gctest.js:1683:16)
    at C:\code\bdwgc\emcc_asyncify\gctest.js:1716:47
    at C:\code\bdwgc\emcc_asyncify\gctest.js:1381:11

C:\code\bdwgc\emcc_asyncify>node middletest.js
^C
```
i.e. gctest still gives the same crash, but middletest.js hangs for some reason, and must be stopped with Ctrl-C. Still that is small progress forward.