### PR TITLE
Fix GC_valloc() to work on Emscripten/WebAssembly.

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1288,6 +1288,14 @@ EXTERN_C_BEGIN
 #     define OS_TYPE "EMSCRIPTEN"
 #     define DATASTART (ptr_t)ALIGNMENT
 #     define DATAEND (ptr_t)ALIGNMENT
+      /* The real page size in WebAssembly is 64KB. However bdwgc does  */
+      /* not support a page size that high, the largest supported page  */
+      /* size is equal to HBLKSIZE (max <= 16KB). Since there is        */
+      /* currently no real virtual memory/page support in Wasm          */
+      /* (see https://github.com/WebAssembly/design/issues/1397 ), the  */
+      /* actual page size does not matter much, so override a fake 4KB  */
+      /* page size for Wasm.                                            */
+#     define GETPAGESIZE() 4096
 #     define USE_MMAP_ANON      /* avoid /dev/zero, not supported */
 #     undef USE_MUNMAP /* mmap(PROT_NONE) is unsupported, mprotect is no-op */
 #   endif


### PR DESCRIPTION
[Physical page size in WebAssembly standard is 64KB](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory/Memory#syntax).

Bdwgc requires that the allocation alignment of a memory allocation request in `GC_memalign()` must be <= HBLKSIZE:

https://github.com/ivmai/bdwgc/blob/400053e428fcd81cf0c867d49223d74de27ccfaa/mallocx.c#L508

This check results in a call to `GC_valloc()` in gctest.js to abort when built to Wasm.

According to documentation, HBLKSIZE is capped to max out at 16KB:

https://github.com/ivmai/bdwgc/blob/400053e428fcd81cf0c867d49223d74de27ccfaa/doc/README.macros#L301-L302

It seems that simplest is to restrict the page size for WebAssembly builds to a fictional 4KB. This fixes the function `GC_valloc()` (which attempts to allocate at physical page alignment) to work in WebAssembly/Emscripten.

Combining this PR with #505 and #506 fixes gctest.js to pass when ASYNCIFY is enabled.

This PR adds a new minimal test for GC_valloc(), which eases observing this kind of issue for Emscripten. This may become useful in the future when WebAssembly standard does add virtual memory support ( https://github.com/dtig/memory-control ) .