### PR TITLE
Fix call to undeclared function emscripten_scan_registers()

### DIFF
--- a/os_dep.c
+++ b/os_dep.c
@@ -1241,11 +1241,11 @@ GC_INNER size_t GC_page_size = 0;
   }
 # define GET_MAIN_STACKBASE_SPECIAL
 #elif defined(EMSCRIPTEN)
+# include <emscripten.h>
 
 # ifdef USE_EMSCRIPTEN_SCAN_STACK
     /* According to the documentation, emscripten_scan_stack() is only  */
     /* guaranteed to be available when building with ASYNCIFY.          */
-#   include <emscripten.h>
 
     static void *emscripten_stack_base;
 


### PR DESCRIPTION
Fix call to undeclared function emscripten_scan_registers(), which regressed in commit https://github.com/ivmai/bdwgc/commit/e4247e8e31621563d53af29910d51ffe1427d3f2 , giving a build error

```
[1/13] Building C object CMakeFiles/gc.dir/os_dep.c.o
FAILED: CMakeFiles/gc.dir/os_dep.c.o
C:\emsdk\emscripten\main\emcc.bat -DENABLE_DISCLAIM -DGC_ATOMIC_UNCOLLECTABLE -DGC_GCJ_SUPPORT -DGC_MISSING_EXECINFO_H -DGC_NOT_DLL -DGC_NO_SIGSETJMP -DJAVA_FINALIZATION -DNO_GETCONTEXT -I../include -O2 -g -DNDEBUG   -DALL_INTERIOR_POINTERS -DNO_EXECUTE_PERMISSION -Wall -Wextra -MD -MT CMakeFiles/gc.dir/os_dep.c.o -MF CMakeFiles\gc.dir\os_dep.c.o.d -o CMakeFiles/gc.dir/os_dep.c.o -c ../os_dep.c
../os_dep.c:2827:7: error: call to undeclared function 'emscripten_scan_registers'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      emscripten_scan_registers(scan_regs_cb);
      ^
1 error generated.
emcc: error: 'C:/emsdk/llvm/git/build_main_vs2019_64/Release/bin\clang.exe -target wasm32-unknown-emscripten -fignore-exceptions -fvisibility=default -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -DEMSCRIPTEN -Werror=implicit-function-declaration -IC:\emsdk\emscripten\main\cache\sysroot\include\SDL --sysroot=C:\emsdk\emscripten\main\cache\sysroot -Xclang -iwithsysroot/include\compat -DENABLE_DISCLAIM -DGC_ATOMIC_UNCOLLECTABLE -DGC_GCJ_SUPPORT -DGC_MISSING_EXECINFO_H -DGC_NOT_DLL -DGC_NO_SIGSETJMP -DJAVA_FINALIZATION -DNO_GETCONTEXT -I../include -O2 -g3 -DNDEBUG -DALL_INTERIOR_POINTERS -DNO_EXECUTE_PERMISSION -Wall -Wextra -MD -MT CMakeFiles/gc.dir/os_dep.c.o -MF CMakeFiles\gc.dir\os_dep.c.o.d -c ../os_dep.c -o CMakeFiles/gc.dir/os_dep.c.o' failed (returned 1)
ninja: build stopped: subcommand failed.
```

Function https://github.com/ivmai/bdwgc/blob/e4247e8e31621563d53af29910d51ffe1427d3f2/os_dep.c#L2827 needs `#include <emscripten.h>`, but that was inadvertently placed inside `# ifdef USE_EMSCRIPTEN_SCAN_STACK`.
