### PR TITLE
Add support for building with wasm32-wasi instead of emscripten

### DIFF
--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -857,7 +857,9 @@ EXTERN_C_END
 # endif
 #endif /* DARWIN */
 
-#include <setjmp.h>
+#ifndef GC_NO_SIGSETJMP
+#  include <setjmp.h>
+#endif
 
 #include <stdio.h>
 

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -857,7 +857,7 @@ EXTERN_C_END
 # endif
 #endif /* DARWIN */
 
-#ifndef WASI
+#ifndef WASI /* wasi does not provide this header */
 #  include <setjmp.h>
 #endif
 

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -857,7 +857,7 @@ EXTERN_C_END
 # endif
 #endif /* DARWIN */
 
-#ifndef GC_NO_SIGSETJMP
+#ifndef WASI
 #  include <setjmp.h>
 #endif
 

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1319,9 +1319,9 @@ EXTERN_C_BEGIN
 #   endif
 #   ifdef WASI
 #     define OS_TYPE "WASI"
-      extern unsigned char __global_base;
+      extern char __global_base;
 #     define DATASTART ((ptr_t)&__global_base)
-      extern unsigned char __heap_base;
+      extern char __heap_base;
 #     define DATAEND ((ptr_t)&__heap_base)
       /* The real page size in WebAssembly is 64 KB.    */
 #     define GETPAGESIZE() 65536

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -484,7 +484,6 @@ EXTERN_C_BEGIN
 #   endif
 #   define I386
 #   define mach_type_known
-#   define WASM
 # endif
 # if defined(__wasi__)
 #   define WASI


### PR DESCRIPTION
I am using bdwgc in a webassembly program that is built directly with LLVM without emscripten - this uses `wasm32-wasi` and wasi-sdk as opposed to `wasm32-unknown`. For the most part, behavior is similar such as lack of threads and the Wasm page size. Some differences are that header files for non-supported features aren't available at all (I had to add a guard to `setjmp.h` which seems possible with an existing macro) and there are symbols for setting the location of the data segment (I think this may actually be the same for emscripten but not sure, it seems to be currently set to just `ALIGNMENT` and I didn't try changing that in this PR). 

For reference, I use this patch to build bdwgc for inclusion in a wasm project here

https://github.com/corazawaf/coraza-proxy-wasm/blob/main/buildtools/bdwgc/Dockerfile

One thing noticable in the Dockerfile was I was able to work around the lack of signals with `-D_WASI_EMULATED_SIGNAL`, but a more precise approach would be guarding the `signal.h` includes. This would mean bringing back a previously deleted `NO_SIGNALS` macro though