### PR TITLE
Emscripten: Remove use of `emscripten_scan_stack()`.

### DIFF
--- a/os_dep.c
+++ b/os_dep.c
@@ -1199,31 +1199,10 @@ GC_INNER size_t GC_page_size = 0;
   }
 # define GET_MAIN_STACKBASE_SPECIAL
 #elif defined(EMSCRIPTEN)
-
-# if defined(USE_EMSCRIPTEN_SCAN_STACK) && defined(EMSCRIPTEN_ASYNCIFY)
-    /* According to the documentation, emscripten_scan_stack() is only  */
-    /* guaranteed to be available when building with ASYNCIFY.          */
-#   include <emscripten.h>
-
-    static void *emscripten_stack_base;
-
-    static void scan_stack_cb(void *begin, void *end)
-    {
-      (void)begin;
-      emscripten_stack_base = end;
-    }
-# else
 #   include <emscripten/stack.h>
-# endif
-
   ptr_t GC_get_main_stack_base(void)
   {
-#   if defined(USE_EMSCRIPTEN_SCAN_STACK) && defined(EMSCRIPTEN_ASYNCIFY)
-      emscripten_scan_stack(scan_stack_cb);
-      return (ptr_t)emscripten_stack_base;
-#   else
       return (ptr_t)emscripten_stack_get_base();
-#   endif
   }
 # define GET_MAIN_STACKBASE_SPECIAL
 #elif !defined(AMIGA) && !defined(HAIKU) && !defined(OS2) \


### PR DESCRIPTION
The code was only enabled by a define and not needed as the alternative is to just use `emscripten_stack_get_base()` which is more straight forward and avoids an extra file-scope static.

There was nothing controlling the define enabling this.