### PR TITLE
WebAssembly: Use MACH_TYPE WEBASSEMBLY, not I386.

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -487,12 +487,12 @@ EXTERN_C_BEGIN
 #   ifndef EMSCRIPTEN
 #     define EMSCRIPTEN
 #   endif
-#   define I386
+#   define WEBASSEMBLY
 #   define mach_type_known
 # endif
 # if defined(__wasi__)
 #   define WASI
-#   define I386
+#   define WEBASSEMBLY
 #   define mach_type_known
 # endif
 
@@ -1314,40 +1314,6 @@ EXTERN_C_BEGIN
         extern int etext[];
 #       define DATASTART ((ptr_t)((((word)(etext)) + 0xfff) & ~0xfff))
 #       define STACKBOTTOM ((ptr_t)0x3ffff000)
-#   endif
-#   ifdef EMSCRIPTEN
-#     define OS_TYPE "EMSCRIPTEN"
-#     define DATASTART (ptr_t)ALIGNMENT
-#     define DATAEND (ptr_t)ALIGNMENT
-      /* Emscripten does emulate mmap and munmap, but those should  */
-      /* not be used in the collector, since WebAssembly lacks the  */
-      /* native support of memory mapping.  Use sbrk() instead.     */
-#     undef USE_MMAP
-#     undef USE_MUNMAP
-      /* The real page size in WebAssembly is 64 KB.    */
-#     if defined(GC_THREADS) && !defined(CPPCHECK)
-#       error No threads support yet
-#     endif
-#   endif
-#   ifdef WASI
-#     define OS_TYPE "WASI"
-      extern char __global_base, __heap_base;
-#     define DATASTART ((ptr_t)&__global_base)
-#     define DATAEND ((ptr_t)&__heap_base)
-#     define STACKBOTTOM ((ptr_t)&__global_base)
-#     ifndef GC_NO_SIGSETJMP
-#       define GC_NO_SIGSETJMP 1 /* no support of signals */
-#     endif
-#     ifndef NO_CLOCK
-#       define NO_CLOCK 1 /* no support of clock */
-#     endif
-#     undef USE_MMAP /* similar to Emscripten */
-#     undef USE_MUNMAP
-      /* The real page size in WebAssembly is 64 KB.    */
-#     define GETPAGESIZE() 65536
-#     if defined(GC_THREADS) && !defined(CPPCHECK)
-#       error No threads support yet
-#     endif
 #   endif
 #   ifdef HAIKU
       extern int etext[];
@@ -2402,6 +2368,49 @@ EXTERN_C_BEGIN
       /* Nothing specific. */
 #   endif
 # endif /* RISCV */
+
+# ifdef WEBASSEMBLY
+#   define MACH_TYPE "WebAssembly"
+#   ifdef __wasm64__
+#     error 64-bit WebAssembly is not yet supported.
+#   endif
+#   define CPU_WORDSZ 32
+#   define ALIGNMENT 4
+#   ifdef EMSCRIPTEN
+#     define OS_TYPE "EMSCRIPTEN"
+#     define DATASTART (ptr_t)ALIGNMENT
+#     define DATAEND (ptr_t)ALIGNMENT
+      /* Emscripten does emulate mmap and munmap, but those should  */
+      /* not be used in the collector, since WebAssembly lacks the  */
+      /* native support of memory mapping.  Use sbrk() instead.     */
+#     undef USE_MMAP
+#     undef USE_MUNMAP
+      /* The real page size in WebAssembly is 64 KB.    */
+#     if defined(GC_THREADS) && !defined(CPPCHECK)
+#       error No threads support yet
+#     endif
+#   endif
+#   ifdef WASI
+#     define OS_TYPE "WASI"
+      extern char __global_base, __heap_base;
+#     define DATASTART ((ptr_t)&__global_base)
+#     define DATAEND ((ptr_t)&__heap_base)
+#     define STACKBOTTOM ((ptr_t)&__global_base)
+#     ifndef GC_NO_SIGSETJMP
+#       define GC_NO_SIGSETJMP 1 /* no support of signals */
+#     endif
+#     ifndef NO_CLOCK
+#       define NO_CLOCK 1 /* no support of clock */
+#     endif
+#     undef USE_MMAP /* similar to Emscripten */
+#     undef USE_MUNMAP
+      /* The real page size in WebAssembly is 64 KB.    */
+#     define GETPAGESIZE() 65536
+#     if defined(GC_THREADS) && !defined(CPPCHECK)
+#       error No threads support yet
+#     endif
+#   endif
+# endif /* WEBASSEMBLY */
 
 #if defined(__GLIBC__) && !defined(DONT_USE_LIBC_PRIVATES)
   /* Use glibc's stack-end marker. */


### PR DESCRIPTION
Instead of using `MACH_TYPE` `I386`, create a new one for `WEBASSEMBLY` for both Emscripten and WASI.

* include/private/gcconfig.h WEBASSEMBLY: Define macro.
* include/private/gcconfig.h [WEBASSEMBLY] __wasm64__: Error as not yet supported.
* include/private/gcconfig.h [WEBASSEMBLY] (CPU_WORDSZ, ALIGNMENT): Define macro.
* include/private/gcconfig.h [__EMSCRIPTEN__]: Define WEBASSEMBLY, not I386.
* include/private/gcconfig.h [__wasi__]: Likewise.
* include/private/gcconfig.h [I386 && EMSCRIPTEN] (OS_TYPE, DATASTART, DATAEND, USE_MMAP, USE_MUNMAP, GC_THREADS && !CPPCHECK): Move to WEBASSEMBLY.
* include/private/gcconfig.h [I386 && WASI] (OS_TYPE, DATASTART, DATAEND, STACKBOTTOM, GC_NO_SIGSETJMP, NO_CLOCK, USE_MMAP, USE_MUNMAP, GETPAGESIZE, GC_THREADS && !CPPCHECK): Likewise.