### PR TITLE
Emscripten, gctest: Remove EXPORTED_FUNCTIONS.

### DIFF
--- a/tests/tests.am
+++ b/tests/tests.am
@@ -30,9 +30,6 @@ if EMSCRIPTEN
 check_PROGRAMS += gctest.html
 gctest_html_SOURCES = $(gctest_SOURCES)
 gctest_html_LDADD = $(gctest_LDADD)
-# Bug in the linker not being able to determine that _memalign and _memset
-# are needed? it's part of mmap.
-gctest_html_LDFLAGS = -s "EXPORTED_FUNCTIONS=['_memalign', '_main', '_memset']"
 endif
 
 TESTS += hugetest$(EXEEXT)


### PR DESCRIPTION
When `mmap` was used, there was apparently a need to export `memalign` and `memset` from the WebAssembly code to JS for the mmap emulation code to use.

The `mmap` code path is no longer used with the Emscripten support, so this export is no longer needed.

The explicit export of `_main` is not required. According to the Emscripten code:

    By default if this setting is not specified on the command
    line the `_main` function will be implicitly exported.

* tests/tests.am [EMSCRIPTEN]: Remove `gctest_html_LDFLAGS`.