### PR TITLE
WebAssembly+cmake: Default to enable_threads=OFF.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,12 +59,17 @@ if (NOT (${CMAKE_VERSION} VERSION_LESS "3.18.0"))
   include(CheckLinkerFlag)
 endif()
 
+set(default_enable_threads ON)
+if(EMSCRIPTEN OR WASI)
+  set(default_enable_threads OFF)
+endif()
+
 # Customize the build by passing "-D<option_name>=ON|OFF" in the command line.
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(build_cord "Build cord library" ON)
 option(build_tests "Build tests" OFF)
 option(enable_docs "Build and install documentation" ON)
-option(enable_threads "Support threads" ON)
+option(enable_threads "Support threads" ${default_enable_threads})
 option(enable_parallel_mark "Parallelize marking and free list construction" ON)
 option(enable_thread_local_alloc "Turn on thread-local allocation optimization" ON)
 option(enable_threads_discovery "Enable threads discovery in GC" ON)


### PR DESCRIPTION
Since the GC doesn't support threading when under Emscripten or WASI, we should default to building without threads.

This was tested with cmake in 3 ways:

* `cmake -GNinja ..` on Linux. Threads remained enabled.
* `emcmake cmake -GNinja ..` with the Emscripten SDK. Threads defaulted to off.
* `cmake -DCMAKE_TOOLCHAIN_FILE=/usr/share/cmake/wasi-sdk.cmake -GNinja ..` with the wasi-sdk under Docker. Threads defaulted to off. (This build had other issues that need to be sorted out.)

If this is approved, I will do one for `enable_mmap` and `enable_munmap` ... or I could add it to this PR as well.
cc: @juj @anuraaga 
