### PR TITLE
Use page size for WASI

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -3008,10 +3008,10 @@ EXTERN_C_BEGIN
 
 /* Whether GC_page_size is to be set to a value other than page size.   */
 #if defined(CYGWIN32) && (defined(MPROTECT_VDB) || defined(USE_MUNMAP)) \
-    || (!defined(ANY_MSWIN) && !defined(USE_MMAP) \
+    || (!defined(ANY_MSWIN) && !defined(WASI) && !defined(USE_MMAP) \
         && (defined(GC_DISABLE_INCREMENTAL) || defined(DEFAULT_VDB)))
   /* Cygwin: use the allocation granularity instead.                    */
-  /* Other than Windows: use HBLKSIZE instead (unless mmap() is used).  */
+  /* Other than Windows or WASI: use HBLKSIZE instead (unless mmap() is used).  */
 # define ALT_PAGESIZE_USED
 # ifndef GC_NO_VALLOC
     /* Nonetheless, we need the real page size is some extra functions. */


### PR DESCRIPTION
I tried updating bdwgc in my WASI build after some time and ran into an issue where sbrk isn't called with page size increments, which is required by wasi

https://github.com/WebAssembly/wasi-libc/blame/ec4566beae84e54952637f0bf61bee4b4cacc087/libc-bottom-half/sources/sbrk.c#L14

This wasn't a problem before so I imagine some code got changed or refactored to affect this, so I added a guard for WASI where it's controlled whether real or fake page size is used.