### PR TITLE
[pthread_support] moving `first_thread_used` to the global Scope

### DIFF
--- a/pthread_support.c
+++ b/pthread_support.c
@@ -618,6 +618,7 @@ GC_INNER GC_thread GC_threads[THREAD_TABLE_SZ] = {0};
 /* other fields (crtn) to be pushed.                                    */
 static struct GC_StackContext_Rep first_crtn;
 static struct GC_Thread_Rep first_thread;
+static GC_bool first_thread_used = FALSE;
 
 /* A place to retain a pointer to an allocated object while a thread    */
 /* registration is ongoing.  Protected by the GC lock.                  */


### PR DESCRIPTION
In this change, we relocate the `first_thread_used` variable to the global scope. This adjustment is made to avoid potential issues that may arise when defining a variable as `static` on the stack in applications with parallel access to such variables.

When a variable is declared as `static` on the stack, compilers typically use a hidden flag to indicate whether the static variable has been initialized. This flag is checked each time the function is entered. While this incurs a minor performance overhead, a more significant concern is the lack of a guarantee that this flag is thread-safe or atomic.

When static variables on the stack are accessed by multiple threads, race conditions can occur, leading to incorrect or even multiple initializations of the variable. Such situations may result in overwriting pointers inside `GC_threads` or `first_thread`, potentially triggering memory cleanup by the GC cycle and causing unforeseen issues to arise.

Notable to say that win32 threads hasn't got that issue.