### PR TITLE
*_allocator<void>: Make members public

### DIFF
--- a/include/gc/gc_allocator.h
+++ b/include/gc/gc_allocator.h
@@ -170,6 +170,7 @@ public:
 
 template<>
 class gc_allocator<void> {
+public:
   typedef GC_ALCTR_SIZE_T    size_type;
   typedef GC_ALCTR_PTRDIFF_T difference_type;
   typedef void*       pointer;
@@ -245,6 +246,7 @@ public:
 
 template<>
 class gc_allocator_ignore_off_page<void> {
+public:
   typedef GC_ALCTR_SIZE_T    size_type;
   typedef GC_ALCTR_PTRDIFF_T difference_type;
   typedef void*       pointer;
@@ -323,6 +325,7 @@ public:
 
 template<>
 class traceable_allocator<void> {
+public:
   typedef GC_ALCTR_SIZE_T    size_type;
   typedef GC_ALCTR_PTRDIFF_T difference_type;
   typedef void*       pointer;


### PR DESCRIPTION
A private value_type is a problem for boost small_vector<X>, which instantiates rebind<void> at some point.

    include/boost/container/allocator_traits.hpp:145:37: error: 'value_type' is a private member of 'traceable_allocator<void>'
       typedef typename allocator_type::value_type value_type;

[...]

    gc_allocator.h:319:23: note: implicitly declared private here
      typedef void        value_type;

I don't see a reason why any of the members should be private, and arguably it violates the Liskov substitution principle. It seems that it was left private by accidental omission.