### PR TITLE
Add constexpr support to allocators for C++20

### DIFF
--- a/include/gc/gc_allocator.h
+++ b/include/gc/gc_allocator.h
@@ -138,34 +138,34 @@ public:
     typedef gc_allocator<GC_Tp1> other;
   };
 
-  gc_allocator() GC_NOEXCEPT {}
-  gc_allocator(const gc_allocator&) GC_NOEXCEPT {}
+  GC_ATTR_CONSTEXPR gc_allocator() GC_NOEXCEPT {}
+  GC_ATTR_CONSTEXPR gc_allocator(const gc_allocator&) GC_NOEXCEPT {}
 # ifndef GC_NO_MEMBER_TEMPLATES
     template <class GC_Tp1> GC_ATTR_EXPLICIT
-    gc_allocator(const gc_allocator<GC_Tp1>&) GC_NOEXCEPT {}
+    GC_ATTR_CONSTEXPR gc_allocator(const gc_allocator<GC_Tp1>&) GC_NOEXCEPT {}
 # endif
-  ~gc_allocator() GC_NOEXCEPT {}
+  GC_ATTR_CONSTEXPR ~gc_allocator() GC_NOEXCEPT {}
 
-  pointer address(reference GC_x) const { return &GC_x; }
-  const_pointer address(const_reference GC_x) const { return &GC_x; }
+  GC_ATTR_CONSTEXPR pointer address(reference GC_x) const { return &GC_x; }
+  GC_ATTR_CONSTEXPR const_pointer address(const_reference GC_x) const { return &GC_x; }
 
   // GC_n is permitted to be 0.  The C++ standard says nothing about what
   // the return value is when GC_n == 0.
-  GC_Tp* allocate(size_type GC_n, const void* = 0) {
+  GC_ATTR_CONSTEXPR GC_Tp* allocate(size_type GC_n, const void* = 0) {
     GC_type_traits<GC_Tp> traits;
     return static_cast<GC_Tp *>(GC_selective_alloc(GC_n * sizeof(GC_Tp),
                                                    traits.GC_is_ptr_free,
                                                    false));
   }
 
-  void deallocate(pointer __p, size_type /* GC_n */) GC_NOEXCEPT
+  GC_ATTR_CONSTEXPR void deallocate(pointer __p, size_type /* GC_n */) GC_NOEXCEPT
     { GC_FREE(__p); }
 
-  size_type max_size() const GC_NOEXCEPT
+  GC_ATTR_CONSTEXPR size_type max_size() const GC_NOEXCEPT
     { return static_cast<GC_ALCTR_SIZE_T>(-1) / sizeof(GC_Tp); }
 
-  void construct(pointer __p, const GC_Tp& __val) { new(__p) GC_Tp(__val); }
-  void destroy(pointer __p) { __p->~GC_Tp(); }
+  GC_ATTR_CONSTEXPR void construct(pointer __p, const GC_Tp& __val) { new(__p) GC_Tp(__val); }
+  GC_ATTR_CONSTEXPR void destroy(pointer __p) { __p->~GC_Tp(); }
 };
 
 template<>
@@ -183,15 +183,15 @@ public:
 };
 
 template <class GC_T1, class GC_T2>
-inline bool operator==(const gc_allocator<GC_T1>&,
-                       const gc_allocator<GC_T2>&) GC_NOEXCEPT
+GC_ATTR_CONSTEXPR inline bool operator==(const gc_allocator<GC_T1>&,
+                                         const gc_allocator<GC_T2>&) GC_NOEXCEPT
 {
   return true;
 }
 
 template <class GC_T1, class GC_T2>
-inline bool operator!=(const gc_allocator<GC_T1>&,
-                       const gc_allocator<GC_T2>&) GC_NOEXCEPT
+GC_ATTR_CONSTEXPR inline bool operator!=(const gc_allocator<GC_T1>&,
+                                         const gc_allocator<GC_T2>&) GC_NOEXCEPT
 {
   return false;
 }
@@ -212,36 +212,36 @@ public:
     typedef gc_allocator_ignore_off_page<GC_Tp1> other;
   };
 
-  gc_allocator_ignore_off_page() GC_NOEXCEPT {}
-  gc_allocator_ignore_off_page(const gc_allocator_ignore_off_page&)
+  GC_ATTR_CONSTEXPR gc_allocator_ignore_off_page() GC_NOEXCEPT {}
+  GC_ATTR_CONSTEXPR gc_allocator_ignore_off_page(const gc_allocator_ignore_off_page&)
     GC_NOEXCEPT {}
 # ifndef GC_NO_MEMBER_TEMPLATES
     template <class GC_Tp1> GC_ATTR_EXPLICIT
-    gc_allocator_ignore_off_page(const gc_allocator_ignore_off_page<GC_Tp1>&)
+    GC_ATTR_CONSTEXPR gc_allocator_ignore_off_page(const gc_allocator_ignore_off_page<GC_Tp1>&)
       GC_NOEXCEPT {}
 # endif
-  ~gc_allocator_ignore_off_page() GC_NOEXCEPT {}
+  GC_ATTR_CONSTEXPR ~gc_allocator_ignore_off_page() GC_NOEXCEPT {}
 
-  pointer address(reference GC_x) const { return &GC_x; }
-  const_pointer address(const_reference GC_x) const { return &GC_x; }
+  GC_ATTR_CONSTEXPR pointer address(reference GC_x) const { return &GC_x; }
+  GC_ATTR_CONSTEXPR const_pointer address(const_reference GC_x) const { return &GC_x; }
 
   // GC_n is permitted to be 0.  The C++ standard says nothing about what
   // the return value is when GC_n == 0.
-  GC_Tp* allocate(size_type GC_n, const void* = 0) {
+  GC_ATTR_CONSTEXPR GC_Tp* allocate(size_type GC_n, const void* = 0) {
     GC_type_traits<GC_Tp> traits;
     return static_cast<GC_Tp *>(GC_selective_alloc(GC_n * sizeof(GC_Tp),
                                                    traits.GC_is_ptr_free,
                                                    true));
   }
 
-  void deallocate(pointer __p, size_type /* GC_n */) GC_NOEXCEPT
+  GC_ATTR_CONSTEXPR void deallocate(pointer __p, size_type /* GC_n */) GC_NOEXCEPT
     { GC_FREE(__p); }
 
-  size_type max_size() const GC_NOEXCEPT
+  GC_ATTR_CONSTEXPR size_type max_size() const GC_NOEXCEPT
     { return static_cast<GC_ALCTR_SIZE_T>(-1) / sizeof(GC_Tp); }
 
-  void construct(pointer __p, const GC_Tp& __val) { new(__p) GC_Tp(__val); }
-  void destroy(pointer __p) { __p->~GC_Tp(); }
+  GC_ATTR_CONSTEXPR void construct(pointer __p, const GC_Tp& __val) { new(__p) GC_Tp(__val); }
+  GC_ATTR_CONSTEXPR void destroy(pointer __p) { __p->~GC_Tp(); }
 };
 
 template<>
@@ -259,15 +259,15 @@ public:
 };
 
 template <class GC_T1, class GC_T2>
-inline bool operator==(const gc_allocator_ignore_off_page<GC_T1>&,
-                       const gc_allocator_ignore_off_page<GC_T2>&) GC_NOEXCEPT
+GC_ATTR_CONSTEXPR inline bool operator==(const gc_allocator_ignore_off_page<GC_T1>&,
+                                         const gc_allocator_ignore_off_page<GC_T2>&) GC_NOEXCEPT
 {
   return true;
 }
 
 template <class GC_T1, class GC_T2>
-inline bool operator!=(const gc_allocator_ignore_off_page<GC_T1>&,
-                       const gc_allocator_ignore_off_page<GC_T2>&) GC_NOEXCEPT
+GC_ATTR_CONSTEXPR inline bool operator!=(const gc_allocator_ignore_off_page<GC_T1>&,
+                                         const gc_allocator_ignore_off_page<GC_T2>&) GC_NOEXCEPT
 {
   return false;
 }
@@ -293,34 +293,34 @@ public:
     typedef traceable_allocator<GC_Tp1> other;
   };
 
-  traceable_allocator() GC_NOEXCEPT {}
-  traceable_allocator(const traceable_allocator&) GC_NOEXCEPT {}
+  GC_ATTR_CONSTEXPR traceable_allocator() GC_NOEXCEPT {}
+  GC_ATTR_CONSTEXPR traceable_allocator(const traceable_allocator&) GC_NOEXCEPT {}
 # ifndef GC_NO_MEMBER_TEMPLATES
     template <class GC_Tp1> GC_ATTR_EXPLICIT
-    traceable_allocator(const traceable_allocator<GC_Tp1>&) GC_NOEXCEPT {}
+    GC_ATTR_CONSTEXPR traceable_allocator(const traceable_allocator<GC_Tp1>&) GC_NOEXCEPT {}
 # endif
-  ~traceable_allocator() GC_NOEXCEPT {}
+  GC_ATTR_CONSTEXPR ~traceable_allocator() GC_NOEXCEPT {}
 
-  pointer address(reference GC_x) const { return &GC_x; }
-  const_pointer address(const_reference GC_x) const { return &GC_x; }
+  GC_ATTR_CONSTEXPR pointer address(reference GC_x) const { return &GC_x; }
+  GC_ATTR_CONSTEXPR const_pointer address(const_reference GC_x) const { return &GC_x; }
 
   // GC_n is permitted to be 0.  The C++ standard says nothing about what
   // the return value is when GC_n == 0.
-  GC_Tp* allocate(size_type GC_n, const void* = 0) {
+  GC_ATTR_CONSTEXPR GC_Tp* allocate(size_type GC_n, const void* = 0) {
     void * obj = GC_MALLOC_UNCOLLECTABLE(GC_n * sizeof(GC_Tp));
     if (0 == obj)
       GC_ALLOCATOR_THROW_OR_ABORT();
     return static_cast<GC_Tp*>(obj);
   }
 
-  void deallocate(pointer __p, size_type /* GC_n */) GC_NOEXCEPT
+  GC_ATTR_CONSTEXPR void deallocate(pointer __p, size_type /* GC_n */) GC_NOEXCEPT
     { GC_FREE(__p); }
 
-  size_type max_size() const GC_NOEXCEPT
+  GC_ATTR_CONSTEXPR size_type max_size() const GC_NOEXCEPT
     { return static_cast<GC_ALCTR_SIZE_T>(-1) / sizeof(GC_Tp); }
 
-  void construct(pointer __p, const GC_Tp& __val) { new(__p) GC_Tp(__val); }
-  void destroy(pointer __p) { __p->~GC_Tp(); }
+  GC_ATTR_CONSTEXPR void construct(pointer __p, const GC_Tp& __val) { new(__p) GC_Tp(__val); }
+  GC_ATTR_CONSTEXPR void destroy(pointer __p) { __p->~GC_Tp(); }
 };
 
 template<>
@@ -338,15 +338,15 @@ public:
 };
 
 template <class GC_T1, class GC_T2>
-inline bool operator==(const traceable_allocator<GC_T1>&,
-                       const traceable_allocator<GC_T2>&) GC_NOEXCEPT
+GC_ATTR_CONSTEXPR inline bool operator==(const traceable_allocator<GC_T1>&,
+                                         const traceable_allocator<GC_T2>&) GC_NOEXCEPT
 {
   return true;
 }
 
 template <class GC_T1, class GC_T2>
-inline bool operator!=(const traceable_allocator<GC_T1>&,
-                       const traceable_allocator<GC_T2>&) GC_NOEXCEPT
+GC_ATTR_CONSTEXPR inline bool operator!=(const traceable_allocator<GC_T1>&,
+                                         const traceable_allocator<GC_T2>&) GC_NOEXCEPT
 {
   return false;
 }

--- a/include/gc/gc_config_macros.h
+++ b/include/gc/gc_config_macros.h
@@ -474,6 +474,14 @@
 # endif
 #endif
 
+#ifndef GC_ATTR_CONSTEXPR
+# if __cplusplus >= 202002L
+#   define GC_ATTR_CONSTEXPR constexpr
+# else
+#   define GC_ATTR_CONSTEXPR /* empty */
+# endif
+#endif
+
 #endif /* __cplusplus */
 
 #endif


### PR DESCRIPTION
This adds the `constexpr` attribute on each allocator member function, including ctors and dtors, to enable easier use of these allocators in compile-time execution. A practical example of this would be a modern C++ string class which supports constexpr construction, usage, and destruction. Without this change, the C++ compiler will not allow such a class.

An trivial example to show the usage:

```cpp
// Compile with: c++ -std=c++20 -Iinclude test.cpp
struct string
{
  constexpr string() = default;
  constexpr ~string() = default;

  gc_allocator<char> a;
};

int main()
{ }
```

This fails to compile before this commit and succeeds afterward. I am using these changes in practice within jank's [0] compiler and runtime here [1].

Note that `constexpr` itself was added in C++11, but it can't apply to destructors until C++20, and it's coming on 2024, so I've skipped over trying to juggle the different levels of `constexpr` here by just saying if you have C++20, you can do what we need.

[0]: https://github.com/jank-lang/jank
[1]: https://github.com/jank-lang/jank/pull/50/files#diff-e0a05b8607cd30211eacb4bc222986254ed8af3942ae602092ca3dbd150121d4