### PR TITLE
Enforce Zig version for `build.zig`

### DIFF
--- a/.github/workflows/zig-build.yml
+++ b/.github/workflows/zig-build.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: "Install zig"
       run: |
-        mkdir zig && curl https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.1849+bb0f7d55e.tar.xz | tar Jx --directory=zig --strip-components=1
+        mkdir zig && curl https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.2015+60958d135.tar.xz | tar Jx --directory=zig --strip-components=1
     - name: Build
       run: >
         zig/zig build

--- a/.github/workflows/zig-cross-compile.yml
+++ b/.github/workflows/zig-cross-compile.yml
@@ -102,7 +102,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: "Install zig"
       run: |
-        mkdir zig && curl https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.1849+bb0f7d55e.tar.xz | tar Jx --directory=zig --strip-components=1
+        mkdir zig && curl https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.2015+60958d135.tar.xz | tar Jx --directory=zig --strip-components=1
     - name: Build
       run: >
         zig/zig build -Dtarget=${{ matrix.ttriple }}

--- a/build.zig
+++ b/build.zig
@@ -10,10 +10,22 @@
 // A script to build and test the collector using Zig build system.
 // The script matches CMakeLists.txt as much as possible.
 
-// TODO: this script assumes zig 0.12.0-dev.1814.
-
 const std = @import("std");
+const builtin = @import("builtin");
 const Path = std.Build.LazyPath;
+
+comptime {
+    const required_zig_version = "0.12.0-dev.1814+5c0d58b71";
+
+    const required_zig = std.SemanticVersion.parse(required_zig_version) 
+        catch unreachable;
+    if (builtin.zig_version.order(required_zig) != .eq) {
+        @compileError(std.fmt.comptimePrint(
+            "Zig version {} does not meet the build requirement of {}",
+            .{ builtin.zig_version, required_zig },
+        ));
+    }
+}
 
 // TODO: specify PACKAGE_VERSION and LIB*_VER_INFO.
 


### PR DESCRIPTION
this is how you do it :)

I'm very happy to see you guys using zig 👍 

We had a massive build system overhaul a couple of days ago (ziglang/zig#18160) and if you'd like, I could port you guys over. You'll need to do it at some point if you wish to complete the todo: 
> update to zig v0.12 final (when released)