### PR TITLE
Test zig build on MacOS too

### DIFF
--- a/.github/workflows/zig-build.yml
+++ b/.github/workflows/zig-build.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     name: ${{ matrix.os }} thr:${{ matrix.enable_threads }} rwlock:${{ matrix.enable_rwlock }} redir:${{ matrix.redirect_malloc }} gcdeb:${{ matrix.enable_gc_debug }} munmap:${{ matrix.enable_munmap }} paramark:${{ matrix.parallel_mark }} thrlocal:${{ matrix.thread_local_alloc }}
     runs-on: ${{ matrix.os  }}
-    timeout-minutes: 4
+    timeout-minutes: 6
 
     strategy:
       fail-fast: false

--- a/.github/workflows/zig-build.yml
+++ b/.github/workflows/zig-build.yml
@@ -5,14 +5,15 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: thr:${{ matrix.enable_threads }} rwlock:${{ matrix.enable_rwlock }} redir:${{ matrix.redirect_malloc }} gcdeb:${{ matrix.enable_gc_debug }} munmap:${{ matrix.enable_munmap }} paramark:${{ matrix.parallel_mark }} thrlocal:${{ matrix.thread_local_alloc }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os }} thr:${{ matrix.enable_threads }} rwlock:${{ matrix.enable_rwlock }} redir:${{ matrix.redirect_malloc }} gcdeb:${{ matrix.enable_gc_debug }} munmap:${{ matrix.enable_munmap }} paramark:${{ matrix.parallel_mark }} thrlocal:${{ matrix.thread_local_alloc }}
+    runs-on: ${{ matrix.os  }}
     timeout-minutes: 4
 
     strategy:
       fail-fast: false
 
       matrix:
+        os: [ macos-latest, ubuntu-latest ]
         gc_assertions: [ true ]
         large_config: [ false ]
         enable_threads: [ false, true ]
@@ -39,9 +40,14 @@ jobs:
     # TODO: move from nightly to zig 0.12 final when released.
     steps:
     - uses: actions/checkout@v4
-    - name: "Install zig"
+    - name: "Install zig on Linux"
+      if: runner.os == 'Linux'
       run: |
         mkdir zig && curl https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.2076+8fd15c6ca.tar.xz | tar Jx --directory=zig --strip-components=1
+    - name: "Install zig on MacOS"
+      if: runner.os == 'macOS'
+      run: |
+        mkdir zig && curl https://ziglang.org/builds/zig-macos-x86_64-0.12.0-dev.2076+8fd15c6ca.tar.xz | tar Jx --directory=zig --strip-components=1
     - name: Build
       run: >
         zig/zig build


### PR DESCRIPTION
This adds so the zig build test runs natively on MacOS too.

Part of #602.