### PR TITLE
Do not add EXTRA_BYTES twice in GC_generic_malloc_many()

### DIFF
--- a/mallocx.c
+++ b/mallocx.c
@@ -252,7 +252,8 @@ GC_API size_t GC_CALL GC_get_expl_freed_bytes_since_gc(void)
 /* GC_malloc_many or friends to replenish it.  (We do not round up      */
 /* object sizes, since a call indicates the intention to consume many   */
 /* objects of exactly this size.)                                       */
-/* We assume that the size is a multiple of GC_GRANULE_BYTES.           */
+/* We assume that the size is a multiple of GC_GRANULE_BYTES, and that  */
+/* EXTRA_BYTES was already added to it.                                 */
 /* We return the free-list by assigning it to *result, since it is      */
 /* not safe to return, e.g. a linked list of pointer-free objects,      */
 /* since the collector would not retain the entire list if it were      */
@@ -433,7 +434,7 @@ GC_API void GC_CALL GC_generic_malloc_many(size_t lb, int k, void **result)
 
     /* As a last attempt, try allocating a single object.  Note that    */
     /* this may trigger a collection or expand the heap.                */
-      op = GC_generic_malloc_inner(lb, k, 0 /* flags */);
+      op = GC_generic_malloc_inner(lb - EXTRA_BYTES, k, 0 /* flags */);
       if (op != NULL) obj_link(op) = NULL;
 
   out:


### PR DESCRIPTION
* mallocx.c (GC_generic_malloc_many): Document that EXTRA_BYTES has already been added to lb. Therefore subtract EXTRA_BYTES before calling GC_generic_malloc_inner(), which also adds it. Otherwise, especially when using thread-local storage, the heap can get filled up with objects of a slightly larger size than requested. When these are freed, they're put on their global free lists, instead of the ones for the actually requested sizes. Thus they're rarely found or transferred to the thread-local free lists of the main requested sizes by GC_generic_malloc_many(). Thread-local allocation is lost, and mutexes end up being raised on almost every allocation, which is very slow with multiple threads. (A similar slowdown happens if you explicitly call GC_FREE() too often from user code.)

This may also fix #453.