### PR TITLE
Provide mechanism to track allocations with heap profiling tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ option(enable_disclaim "Support alternative finalization interface" ON)
 option(enable_dynamic_pointer_mask "Support pointer mask/shift set at runtime" OFF)
 option(enable_large_config "Optimize for large heap or root set" OFF)
 option(enable_gc_assertions "Enable collector-internal assertion checking" OFF)
+option(enable_track_valgrind "Support tracking GC_malloc and friends for heap profiling tools" OFF)
 option(enable_mmap "Use mmap instead of sbrk to expand the heap" OFF)
 option(enable_munmap "Return page to the OS if empty for N collections" ON)
 option(enable_dynamic_loading "Enable tracing of dynamic library data roots" ON)
@@ -101,7 +102,6 @@ option(enable_emscripten_asyncify "Use Emscripten asyncify feature" OFF)
 option(install_headers "Install header and pkg-config metadata files" ON)
 option(with_libatomic_ops "Use an external libatomic_ops" OFF)
 option(without_libatomic_ops "Use atomic_ops.h in libatomic_ops/src" OFF)
-option(enable_track_valgrind "Support tracking GC_malloc and friends for heap profiling tools" OFF)
 
 # Override the default build type to RelWithDebInfo (this instructs cmake to
 # pass -O2 -g -DNDEBUG options to the compiler by default).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ option(enable_emscripten_asyncify "Use Emscripten asyncify feature" OFF)
 option(install_headers "Install header and pkg-config metadata files" ON)
 option(with_libatomic_ops "Use an external libatomic_ops" OFF)
 option(without_libatomic_ops "Use atomic_ops.h in libatomic_ops/src" OFF)
+option(enable_track_valgrind "Support tracking GC_malloc and friends for heap profiling tools" OFF)
 
 # Override the default build type to RelWithDebInfo (this instructs cmake to
 # pass -O2 -g -DNDEBUG options to the compiler by default).
@@ -713,6 +714,10 @@ if (build_cord)
           RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
           INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 endif(build_cord)
+
+if (enable_valgrind_tracking)
+  add_definitions("-DVALGRIND_TRACKING")
+endif()
 
 if (BUILD_SHARED_LIBS AND HAVE_FLAG_WL_NO_UNDEFINED)
   # Declare that the libraries do not refer to external symbols.

--- a/allchblk.c
+++ b/allchblk.c
@@ -1005,7 +1005,7 @@ STATIC struct hblk *GC_allochblk_nth(size_t lb_adjusted, int k,
     return hbp;
 }
 
-# if defined(VALGRIND_TRACKING)
+# ifdef VALGRIND_TRACKING
     GC_API void GC_CALL GC_free_profiler_hook(void * p) {
         UNUSED_ARG(p);
     }

--- a/allchblk.c
+++ b/allchblk.c
@@ -1008,7 +1008,7 @@ STATIC struct hblk *GC_allochblk_nth(size_t lb_adjusted, int k,
 # ifdef VALGRIND_TRACKING
 /* This function is called from the sweeper whenever an object is      */
 /* freed.                                                              */
-    GC_API void GC_CALL GC_free_profiler_hook(void * p) {
+    GC_ATTR_NOINLINE GC_API void GC_CALL GC_free_profiler_hook(void * p) {
         GC_noop1((word)(p));
     }
 # endif

--- a/allchblk.c
+++ b/allchblk.c
@@ -1005,6 +1005,12 @@ STATIC struct hblk *GC_allochblk_nth(size_t lb_adjusted, int k,
     return hbp;
 }
 
+# if defined(VALGRIND_TRACKING)
+    GC_API void GC_CALL GC_free_profiler_hook(void * p) {
+        UNUSED_ARG(p);
+    }
+# endif
+
 /*
  * Free a heap block.
  *

--- a/allchblk.c
+++ b/allchblk.c
@@ -1006,6 +1006,8 @@ STATIC struct hblk *GC_allochblk_nth(size_t lb_adjusted, int k,
 }
 
 # ifdef VALGRIND_TRACKING
+/* This function is called from the sweeper whenever an object is      */
+/* freed.                                                              */
     GC_API void GC_CALL GC_free_profiler_hook(void * p) {
         GC_noop1((word)(p));
     }

--- a/allchblk.c
+++ b/allchblk.c
@@ -1007,7 +1007,7 @@ STATIC struct hblk *GC_allochblk_nth(size_t lb_adjusted, int k,
 
 # ifdef VALGRIND_TRACKING
     GC_API void GC_CALL GC_free_profiler_hook(void * p) {
-        UNUSED_ARG(p);
+        GC_noop1((word)(p));
     }
 # endif
 

--- a/allchblk.c
+++ b/allchblk.c
@@ -1009,7 +1009,7 @@ STATIC struct hblk *GC_allochblk_nth(size_t lb_adjusted, int k,
 /* This function is called from the sweeper whenever an object is      */
 /* freed.                                                              */
     GC_ATTR_NOINLINE GC_API void GC_CALL GC_free_profiler_hook(void * p) {
-        GC_noop1((word)(p));
+        GC_noop1((word)p);
     }
 # endif
 

--- a/build.zig
+++ b/build.zig
@@ -94,6 +94,8 @@ pub fn build(b: *std.Build) void {
         "Optimize for large heap or root set") orelse false;
     const enable_gc_assertions = b.option(bool, "enable_gc_assertions",
         "Enable collector-internal assertion checking") orelse false;
+    const enable_valgrind_tracking = b.option(bool, "enable_valgrind_tracking",
+        "Support tracking GC_malloc and friends for heap profiling tools") orelse false;
     const enable_mmap = b.option(bool, "enable_mmap",
         "Use mmap instead of sbrk to expand the heap") orelse false;
     const enable_munmap = b.option(bool, "enable_munmap",
@@ -318,6 +320,10 @@ pub fn build(b: *std.Build) void {
 
     if (enable_gc_assertions) {
         flags.append("-D GC_ASSERTIONS") catch unreachable;
+    }
+
+    if (enable_valgrind_tracking) {
+        flags.append("-D VALGRIND_TRACKING") catch unreachable;
     }
 
     if (!enable_threads_discovery) {

--- a/configure.ac
+++ b/configure.ac
@@ -1037,7 +1037,7 @@ AC_ARG_ENABLE(valgrind-tracking,
         [heap profiler allocation tracking])])
 if test "${enable_valgrind_tracking}" = yes; then
     AC_DEFINE([VALGRIND_TRACKING], 1,
-              [Define to enable heap profiler allocation tracking.])
+              [Define to support tracking GC_malloc and friends for heap profiling tools.])
 fi
 
 AC_ARG_ENABLE(mmap,

--- a/configure.ac
+++ b/configure.ac
@@ -1032,6 +1032,14 @@ if test "${enable_gc_assertions}" = yes; then
               [Define to enable internal debug assertions.])
 fi
 
+AC_ARG_ENABLE(valgrind-tracking,
+    [AS_HELP_STRING([--enable-valgrind-tracking],
+        [heap profiler allocation tracking])])
+if test "${enable_valgrind_tracking}" = yes; then
+    AC_DEFINE([VALGRIND_TRACKING], 1,
+              [Define to enable heap profiler allocation tracking.])
+fi
+
 AC_ARG_ENABLE(mmap,
     [AS_HELP_STRING([--enable-mmap],
                     [use mmap instead of sbrk to expand the heap])],

--- a/include/gc/gc.h
+++ b/include/gc/gc.h
@@ -615,6 +615,8 @@ GC_API void GC_CALL GC_free(void *);
 /* This function is called from the sweeper whenever an object is       */
 /* freed, which can then be intercepted by heap profilers so that       */
 /* they can accurately track allocations.                               */
+/*                                                                      */
+/* Defined only if the library has been compiled with VALGRIND_TRACKING.*/
 GC_API void GC_free_profiler_hook(void *);
 
 /* The "stubborn" objects allocation is not supported anymore.  Exists  */

--- a/include/gc/gc.h
+++ b/include/gc/gc.h
@@ -605,6 +605,20 @@ GC_API int GC_CALL GC_posix_memalign(void ** /* memptr */, size_t /* align */,
 /* GC_free(0) is a no-op, as required by ANSI C for free.               */
 GC_API void GC_CALL GC_free(void *);
 
+# if defined(VALGRIND_TRACKING)
+/* Notify heap profiling tools that an object was deallocated.          */
+/* Programs such as Valgrind massif and KDE heaptrack track allocated   */
+/* objects by overriding common allocator methods (e.g. malloc and      */
+/* free). However, because GC doesn't work by calling a standard alloc  */
+/* methods on objects which were reclaimed, we need a way to tell       */
+/* profilers that an object has been freed.                             */
+/*                                                                      */
+/* This function is called from the sweeper whenever an object is       */
+/* freed, which can then be intercepted by heap profilers so that       */
+/* they can accurately track allocations.                               */
+    GC_API void GC_free_profiler_hook(void *);
+# endif
+
 /* The "stubborn" objects allocation is not supported anymore.  Exists  */
 /* only for the backward compatibility.                                 */
 #define GC_MALLOC_STUBBORN(sz)  GC_MALLOC(sz)

--- a/include/gc/gc.h
+++ b/include/gc/gc.h
@@ -605,16 +605,17 @@ GC_API int GC_CALL GC_posix_memalign(void ** /* memptr */, size_t /* align */,
 /* GC_free(0) is a no-op, as required by ANSI C for free.               */
 GC_API void GC_CALL GC_free(void *);
 
-/* Notify heap profiling tools that an object was deallocated.          */
+/* A symbol to be intercepted by heap profilers so that they can        */
+/* accurately track allocations.                                        */
+/*                                                                      */
 /* Programs such as Valgrind massif and KDE heaptrack track allocated   */
 /* objects by overriding common allocator methods (e.g. malloc and      */
 /* free). However, because GC doesn't work by calling a standard alloc  */
 /* methods on objects which were reclaimed, we need a way to tell       */
 /* profilers that an object has been freed.                             */
 /*                                                                      */
-/* This function is called from the sweeper whenever an object is       */
-/* freed, which can then be intercepted by heap profilers so that       */
-/* they can accurately track allocations.                               */
+/* This function is not intended to be called by the client, it should  */
+/* be used for the interception purpose only.                           */
 /*                                                                      */
 /* Defined only if the library has been compiled with VALGRIND_TRACKING.*/
 GC_API void GC_free_profiler_hook(void *);

--- a/include/gc/gc.h
+++ b/include/gc/gc.h
@@ -605,7 +605,6 @@ GC_API int GC_CALL GC_posix_memalign(void ** /* memptr */, size_t /* align */,
 /* GC_free(0) is a no-op, as required by ANSI C for free.               */
 GC_API void GC_CALL GC_free(void *);
 
-# if defined(VALGRIND_TRACKING)
 /* Notify heap profiling tools that an object was deallocated.          */
 /* Programs such as Valgrind massif and KDE heaptrack track allocated   */
 /* objects by overriding common allocator methods (e.g. malloc and      */
@@ -616,8 +615,7 @@ GC_API void GC_CALL GC_free(void *);
 /* This function is called from the sweeper whenever an object is       */
 /* freed, which can then be intercepted by heap profilers so that       */
 /* they can accurately track allocations.                               */
-    GC_API void GC_free_profiler_hook(void *);
-# endif
+GC_API void GC_free_profiler_hook(void *);
 
 /* The "stubborn" objects allocation is not supported anymore.  Exists  */
 /* only for the backward compatibility.                                 */

--- a/malloc.c
+++ b/malloc.c
@@ -651,6 +651,10 @@ GC_API void GC_CALL GC_free(void * p)
         return;
     }
 
+#   if defined(VALGRIND_TRACKING)
+      GC_free_profiler_hook(p);
+#   endif
+
 #   ifdef LOG_ALLOCS
       GC_log_printf("GC_free(%p) after GC #%lu\n",
                     p, (unsigned long)GC_gc_no);

--- a/malloc.c
+++ b/malloc.c
@@ -651,7 +651,7 @@ GC_API void GC_CALL GC_free(void * p)
         return;
     }
 
-#   if defined(VALGRIND_TRACKING)
+#   ifdef VALGRIND_TRACKING
       GC_free_profiler_hook(p);
 #   endif
 

--- a/malloc.c
+++ b/malloc.c
@@ -650,11 +650,9 @@ GC_API void GC_CALL GC_free(void * p)
         /* Required by ANSI.  It's not my fault ...     */
         return;
     }
-
 #   ifdef VALGRIND_TRACKING
       GC_free_profiler_hook(p);
 #   endif
-
 #   ifdef LOG_ALLOCS
       GC_log_printf("GC_free(%p) after GC #%lu\n",
                     p, (unsigned long)GC_gc_no);

--- a/reclaim.c
+++ b/reclaim.c
@@ -200,7 +200,7 @@ STATIC ptr_t GC_reclaim_clear(struct hblk *hbp, hdr *hhdr, word sz,
                 obj_link(p) = list;
                 list = p;
 
-#             if defined(VALGRIND_TRACKING)
+#             ifdef VALGRIND_TRACKING
                 GC_free_profiler_hook(p);
 #             endif
 
@@ -231,7 +231,7 @@ STATIC ptr_t GC_reclaim_uninit(struct hblk *hbp, hdr *hhdr, word sz,
                 n_bytes_found += sz;
                 /* object is available - put on list */
                     obj_link(p) = list;
-#                   if defined(VALGRIND_TRACKING)
+#                   ifdef VALGRIND_TRACKING
                       GC_free_profiler_hook(p);
 #                   endif
                     list = ((ptr_t)p);
@@ -298,7 +298,7 @@ STATIC void GC_reclaim_check(struct hblk *hbp, hdr *hhdr, word sz)
     }
 }
 
-# if defined(VALGRIND_TRACKING)
+# ifdef VALGRIND_TRACKING
 /* Call GC_free_profiler_hook on freed objects so that profiling      */
 /* tools can track allocations.                                       */
 STATIC void GC_reclaim_check_for_profiler(struct hblk *hbp, word sz)
@@ -459,7 +459,7 @@ STATIC void GC_CALLBACK GC_reclaim_block(struct hblk *hbp,
               }
               GC_bytes_found += (signed_word)sz;
               GC_freehblk(hbp);
-#             if defined(VALGRIND_TRACKING)
+#             ifdef VALGRIND_TRACKING
                 GC_free_profiler_hook(hbp);
 #             endif
             }
@@ -487,7 +487,7 @@ STATIC void GC_CALLBACK GC_reclaim_block(struct hblk *hbp,
 #       else
           GC_ASSERT(sz * hhdr -> hb_n_marks <= HBLKSIZE);
 #       endif
-#       if defined(VALGRIND_TRACKING)
+#       ifdef VALGRIND_TRACKING
           GC_reclaim_check_for_profiler(hbp, sz);
 #       endif
         if (report_if_found) {
@@ -502,7 +502,7 @@ STATIC void GC_CALLBACK GC_reclaim_block(struct hblk *hbp,
           /* else */ {
             GC_bytes_found += (signed_word)HBLKSIZE;
             GC_freehblk(hbp);
-#           if defined(VALGRIND_TRACKING)
+#           ifdef VALGRIND_TRACKING
               GC_free_profiler_hook(hbp);
 #           endif
           }

--- a/reclaim.c
+++ b/reclaim.c
@@ -199,11 +199,9 @@ STATIC ptr_t GC_reclaim_clear(struct hblk *hbp, hdr *hhdr, word sz,
                 /* Object is available - put it on list. */
                 obj_link(p) = list;
                 list = p;
-
 #             ifdef VALGRIND_TRACKING
                 GC_free_profiler_hook(p);
 #             endif
-
                 p = (ptr_t)GC_clear_block((word *)p, sz, pcount);
             }
             bit_no += MARK_BIT_OFFSET(sz);


### PR DESCRIPTION
Tools such as Valgrind's massif[1] and KDE heaptrack[2] work by intercepting dynamically linked allocator calls so that they can do their own bookkeeping for tracking memory usage. While this enables them to trivially hook into any of the BDWGC calls which allocate, they aren't currently able to tell when the GC frees memory.

This commit introduces a new function to the API, `GC_free_profiler_hook`, which is called for each object during the reclaim phase of the GC. It provides a stub for heap profiling tools to override so that they can see which objects were freed.

This functionality is feature gated behind the `-DVALGRIND_TRACKING` flag.

[1]: https://valgrind.org/docs/manual/ms-manual.html
[2]: https://github.com/KDE/heaptrack