### PR TITLE
build.zig: Support ignore_free

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -88,6 +88,8 @@ pub fn build(b: *std.Build) void {
         "Support for atomic uncollectible allocation") orelse true;
     const enable_redirect_malloc = b.option(bool, "enable_redirect_malloc",
         "Redirect malloc and friend to GC routines") orelse false;
+    const enable_ignore_free = b.option(bool, "enable_ignore_free",
+        "Ignore calls to free") orelse false;
     const enable_disclaim = b.option(bool, "enable_disclaim",
         "Support alternative finalization interface") orelse true;
     const enable_dynamic_pointer_mask = b.option(bool,
@@ -301,6 +303,10 @@ pub fn build(b: *std.Build) void {
         } else {
             flags.append("-D GC_USE_DLOPEN_WRAP") catch unreachable;
         }
+    }
+
+    if (enable_ignore_free) {
+        flags.append("-D IGNORE_FREE") catch unreachable;
     }
 
     if (enable_mmap or enable_munmap) {

--- a/malloc.c
+++ b/malloc.c
@@ -698,7 +698,7 @@ GC_API void GC_CALL GC_free(void * p)
   void free(void * p)
   {
 #   ifdef IGNORE_FREE
-#     UNUSED_ARG(p);
+      UNUSED_ARG(p);
 #   else
 #     if defined(GC_LINUX_THREADS) && !defined(USE_PROC_FOR_LIBRARIES)
         /* Don't bother with initialization checks.  If nothing         */


### PR DESCRIPTION
Add new enable_ignore_free option to build.zig and fix an actual bug related to the implementation of ignore_free. That it was a comment must have been a mistake. I made the original comment that adds the `UNUSED_ARG(p)` line so no idea how I messed that up, perhaps some rebase issue, but this fixes it!