### PR TITLE
Zig-build improvements: MSVC & C++

### DIFF
--- a/.github/workflows/zig-build.yml
+++ b/.github/workflows/zig-build.yml
@@ -104,5 +104,6 @@ jobs:
         -Denable_rwlock=${{ matrix.enable_rwlock }}
         -Denable_thread_local_alloc=${{ matrix.thread_local_alloc }}
         -Denable_threads=${{ matrix.enable_threads }}
+        -Denable_cplusplus=${{ matrix.enable_cplusplus }}
         -Denable_werror
         test

--- a/build.zig
+++ b/build.zig
@@ -675,6 +675,9 @@ pub fn build(b: *std.Build) void {
     if (enable_gc_debug) {
         addTest(b, gc, test_step, flags, "tracetest", "tests/trace.c");
     }
+    if(enable_cplusplus) {
+        addTest(b, gccpp, test_step, flags, "cpptest", "tests/cpp.cc");
+    }
     if (enable_threads) {
         addTest(b, gc, test_step, flags, "atomicopstest", "tests/atomicops.c");
         addTest(b, gc, test_step, flags,


### PR DESCRIPTION
closes #635 

Not only does this change the build for the msvc target. It also adds support for C++ libraries.

Note: CI is now using a GH-action plugin to download (faster and more manageable) zig-tarballs.
- [korandoru/setup-zig](https://github.com/korandoru/setup-zig) - allow release version or master (fatest - no-cached)
- [goto-bus-stop/setup-zig](https://github.com/goto-bus-stop/setup-zig) - allow same `korandoru`, but you can also specify the -dev version. (no-cached)