### PR TITLE
Zig: MacOS SDK for cross-compile

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -423,6 +423,12 @@ pub fn build(b: *std.Build) void {
         // and HAVE_PTHREAD_SET_NAME_NP targets.
     }
 
+    // cross-compile for Darwin only
+    if (t.isDarwin() and !target.query.isNative()) {
+        flags.append("-D NO_MPROTECT_VDB") catch unreachable;
+        flags.append("-D MISSING_MACH_O_GETSECT_H") catch unreachable;
+    }
+
     // Define to use 'dladdr' function (used for debugging).
     flags.append("-D HAVE_DLADDR") catch unreachable;
 


### PR DESCRIPTION
e.g.: Build Linux to MacOS (both x86_64)

### Fix

```bash
zig build --summary all -Dtarget=native-macos
install
└─ install gc
   └─ zig build-lib gc Debug native-macos 1 errors
/home/kassane/bdwgc/extra/../os_dep.c:4453:10: error: 'mach/exception.h' file not found
#include <mach/exception.h>
         ^~~~~~~~~~~~~~~~~~~
/home/kassane/bdwgc/extra/gc.c:62:10: note: in file included from /home/kassane/bdwgc/extra/gc.c:62:
#include "../os_dep.c"
         ^
```

cc: @ivmai 

### Reference
- https://github.com/ziglang/zig/issues/18257