### PR TITLE
Add skip_cpp_definitions to gc_cpp.cc

### DIFF
--- a/docs/README.macros
+++ b/docs/README.macros
@@ -269,7 +269,7 @@ REDIRECT_FREE=<X>       Causes free to be redirected to X.  The canonical use
   is REDIRECT_FREE=GC_debug_free.
 
 SKIP_CPP_DEFINITIONS    Do not include definitions for new, delete, etc in 
-  gc_cpp.h. This might be necessary for static compilation for user-supplied 
+  gc_cpp.cc. This might be necessary for static compilation for user-supplied 
   allocation definitions.
 
 IGNORE_FREE     Turns calls to free into a no-op.  Only useful with

--- a/docs/README.macros
+++ b/docs/README.macros
@@ -268,6 +268,10 @@ REDIRECT_REALLOC=<X>    Causes realloc to be redirected to X.
 REDIRECT_FREE=<X>       Causes free to be redirected to X.  The canonical use
   is REDIRECT_FREE=GC_debug_free.
 
+SKIP_CPP_DEFINITIONS    Do not include definitions for new, delete, etc in 
+  gc_cpp.h. This might be necessary for static compilation for user-supplied 
+  allocation definitions.
+
 IGNORE_FREE     Turns calls to free into a no-op.  Only useful with
   REDIRECT_MALLOC.
 

--- a/gc_cpp.cc
+++ b/gc_cpp.cc
@@ -38,7 +38,7 @@ built-in "new" and "delete".
 #endif
 #include "gc/gc_cpp.h"
 
-#if (!defined(_MSC_VER) && !defined(__DMC__) \
+#if !defined(SKIP_CPP_DEFINITIONS) && (!defined(_MSC_VER) && !defined(__DMC__) \
      || defined(GC_NO_INLINE_STD_NEW)) && !defined(GC_INLINE_STD_NEW)
 
 # if defined(GC_NEW_ABORTS_ON_OOM) || defined(_LIBCPP_NO_EXCEPTIONS)


### PR DESCRIPTION
Trying to compile a static BDWGC build with your own overrides for the allocation functions can lead to a duplicate definition error for the C++ operators (new, delete, new[],..). This PR adds a define directive to skip these definitions, if requested. 