### PR TITLE
use g instead of X for tinyc asm constraint

### DIFF
--- a/include/gc/gc.h
+++ b/include/gc/gc.h
@@ -1537,6 +1537,9 @@ GC_API int GC_CALL GC_invoke_finalizers(void);
 # if defined(__e2k__)
 #   define GC_reachable_here(ptr) \
                 __asm__ __volatile__ (" " : : "r"(ptr) : "memory")
+# elif defined(__TINYC__)
+#   define GC_reachable_here(ptr) \
+                __asm__ __volatile__ (" " : : "g"(ptr) : "memory")
 # else
 #   define GC_reachable_here(ptr) \
                 __asm__ __volatile__ (" " : : "X"(ptr) : "memory")


### PR DESCRIPTION
The Tiny C compiler does not handle the `X` asm constraint.  Use the `g`  constraint instead. 