### PR TITLE
Move atomic_ops libs into private so that it won't confuse downstream packages

### DIFF
--- a/bdw-gc.pc.in
+++ b/bdw-gc.pc.in
@@ -6,5 +6,6 @@ includedir=@includedir@
 Name: Boehm-Demers-Weiser Conservative Garbage Collector
 Description: A garbage collector for C and C++
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} @ATOMIC_OPS_LIBS@ -lgc @THREADDLLIBS@
+Libs: -L${libdir} -lgc @THREADDLLIBS@
+Libs.private: @ATOMIC_OPS_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Acturally, bdwgc it self may requires atomic_ops, but it does not require downstream packages (like guile) requires atomic_ops. So I would suggest that move `@ATOMIC_OPS_LIBS@` into `Libs.private`, so that won't confuse downstream packages, especially when performing check.