### PR TITLE
Move atomic_ops libs into Requires.private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,7 @@ set(SRC allchblk.c alloc.c blacklst.c dbg_mlc.c dyn_load.c finalize.c
 
 set(NODIST_SRC)
 set(ATOMIC_OPS_LIBS)
+set(ATOMIC_OPS_PC)
 set(ATOMIC_OPS_LIBS_CMAKE)
 set(THREADDLLIBS_LIST)
 set(NEED_LIB_RT)
@@ -197,6 +198,7 @@ if (enable_threads)
         "with_libatomic_ops and without_libatomic_ops are mutually exclusive")
     endif()
     set(ATOMIC_OPS_LIBS "-latomic_ops")
+    set(ATOMIC_OPS_PC "atomic_ops")
     find_package(Atomic_ops CONFIG)
     if (Atomic_ops_FOUND)
       get_target_property(AO_INCLUDE_DIRS Atomic_ops::atomic_ops

--- a/bdw-gc.pc.in
+++ b/bdw-gc.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: Boehm-Demers-Weiser Conservative Garbage Collector
 Description: A garbage collector for C and C++
 Version: @PACKAGE_VERSION@
+Requires.private: @ATOMIC_OPS_PC@
 Libs: -L${libdir} -lgc @THREADDLLIBS@
-Libs.private: @ATOMIC_OPS_LIBS@
 Cflags: -I${includedir}

--- a/configure.ac
+++ b/configure.ac
@@ -1207,7 +1207,9 @@ AS_IF([test x"$with_libatomic_ops" != xno],
   [AS_IF([test x"$with_libatomic_ops" != xnone -a x"$THREADS" != xnone],
          [AC_MSG_RESULT([external])
           ATOMIC_OPS_LIBS="-latomic_ops"
-          AC_SUBST([ATOMIC_OPS_LIBS])],
+          ATOMIC_OPS_PC="atomic_ops"
+          AC_SUBST([ATOMIC_OPS_LIBS])
+          AC_SUBST([ATOMIC_OPS_PC])],
          [AC_MSG_RESULT([none])
           AS_IF([test x"$THREADS" != xnone],
                 [AC_DEFINE([GC_BUILTIN_ATOMIC], [1],


### PR DESCRIPTION
Acturally, bdwgc it self may requires atomic_ops, but it does not require downstream packages (like guile) requires atomic_ops. So I would suggest that move `@ATOMIC_OPS_LIBS@` into `Requires.private`, so that won't confuse downstream packages, especially when performing check.

https://people.freedesktop.org/~dbn/pkg-config-guide.html#faq
> My library `z` uses `libx` internally, but does not expose `libx` data types in its public API. What do I put in my `z.pc` file?
> Again, add the module to `Requires.private` if it supports `pkg-config`. In this case, the compiler flags will be emitted unnecessarily, but it ensures that the linker flags will be present when linking statically. If `libx` does not support `pkg-config`, add the necessary linker flags to `Libs.private`.

So I think, move `atomic_ops` is a more appropriate solution.