### PR TITLE
Avoid legacy macros in LoongArch's definition of CPP_WORDSZ

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1593,7 +1593,7 @@ extern char **environ;
 
 #ifdef LOONGARCH
 #  define MACH_TYPE "LOONGARCH"
-#  define CPP_WORDSZ _LOONGARCH_SZPTR
+#  define CPP_WORDSZ (__SIZEOF_POINTER__ * 8)
 #  ifdef LINUX
 #    pragma weak __data_start
 extern int __data_start[];


### PR DESCRIPTION
Predefined macro _LOONGARCH_SZPTR is considered legacy[1], should be neither used in new code nor implemented in new compiler, so let's switch to a more portable definition.

This fixes building on Clang.

[1]: https://github.com/loongson/LoongArch-Documentation/blob/e2fb720ef303fd57c27eb1c80d4722dc6b5763c9/docs/LoongArch-toolchain-conventions-EN.adoc?plain=1#L516-L557

* include/private/gcconfig.h [LOONGARCH]: replace _LOONGARCH_SZPTR with __SIZEOF_POINTER__.