### PR TITLE
Rework Haiku port.

### DIFF
--- a/dyn_load.c
+++ b/dyn_load.c
@@ -1418,7 +1418,7 @@ GC_register_dynamic_libraries(void)
   int32 cookie = 0;
 
   GC_ASSERT(I_HOLD_LOCK());
-  while (get_next_image_info(0, &cookie, &info) == B_OK) {
+  while (get_next_image_info(B_CURRENT_TEAM, &cookie, &info) == B_OK) {
     ptr_t data = (ptr_t)info.data;
     GC_add_roots_inner(data, data + info.data_size, TRUE);
   }

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -895,7 +895,19 @@ extern char etext[];
 #ifdef HAIKU
 #  define OS_TYPE "HAIKU"
 #  define DYNAMIC_LOADING
-#  define MPROTECT_VDB
+#  define USE_GET_STACKBASE_FOR_MAIN
+#  undef MPROTECT_VDB		/* slow */
+#  ifndef HAVE_PTHREAD_GETATTR_NP
+#    define HAVE_PTHREAD_GETATTR_NP 1
+#  endif
+#  ifndef HAVE_CLOCK_GETTIME
+#    define HAVE_CLOCK_GETTIME 1
+#  endif
+#  ifndef USE_MMAP
+#    define USE_MMAP 1
+#  endif
+#  define USE_MMAP_ANON
+#  define USE_SPIN_LOCK
 EXTERN_C_END
 #  include <OS.h>
 EXTERN_C_BEGIN
@@ -1351,8 +1363,7 @@ extern int etext[];
 #    define STACKBOTTOM MAKE_CPTR(0x3ffff000)
 #  endif
 #  ifdef HAIKU
-extern int etext[];
-#    define DATASTART PTR_ALIGN_UP((ptr_t)etext, 0x1000)
+/* Nothing specific. */
 #  endif
 #  ifdef HURD
 /* Nothing specific. */
@@ -2247,8 +2258,7 @@ extern int _end[];
 /* Nothing specific. */
 #  endif
 #  ifdef HAIKU
-#    define HEURISTIC2
-#    define SEARCH_FOR_DATA_START
+/* Nothing specific. */
 #  endif
 #  ifdef HURD
 /* Nothing specific. */
@@ -3431,9 +3441,6 @@ void *psp2_get_mem(size_t bytes);
 #  elif defined(NINTENDO_SWITCH)
 void *switch_get_mem(size_t bytes);
 #    define GET_MEM(bytes) (struct hblk *)switch_get_mem(bytes)
-#  elif defined(HAIKU)
-ptr_t GC_haiku_get_mem(size_t bytes);
-#    define GET_MEM(bytes) (struct hblk *)GC_haiku_get_mem(bytes)
 #  elif defined(EMSCRIPTEN_TINY)
 void *emmalloc_memalign(size_t alignment, size_t size);
 #    define GET_MEM(bytes) \

--- a/misc.c
+++ b/misc.c
@@ -2174,6 +2174,10 @@ GC_default_on_abort(const char *msg)
 #  else
     __android_log_assert("*" /* cond */, GC_ANDROID_LOG_TAG, "%s\n", msg);
 #  endif
+
+#  if defined(__HAIKU__)
+    debugger(msg);
+#  endif
   }
 
 #  if !defined(NO_DEBUGGING) && !defined(GC_ANDROID_LOG)

--- a/pthread_support.c
+++ b/pthread_support.c
@@ -1510,12 +1510,7 @@ fork_child_proc(void)
 #    endif
 #    ifdef PARALLEL_MARK
   if (GC_parallel) {
-#      if defined(THREAD_SANITIZER) && defined(GC_ASSERTIONS) \
-          && defined(CAN_CALL_ATFORK)
-    (void)pthread_mutex_unlock(&mark_mutex);
-#      else
-    GC_release_mark_lock();
-#      endif
+    pthread_mutex_init(&mark_mutex, NULL);
     /* Turn off parallel marking in the child, since we are probably  */
     /* just going to exec, and we would have to restart mark threads. */
     GC_parallel = FALSE;
@@ -2726,11 +2721,6 @@ GC_wrap_pthread_create(pthread_t *new_thread,
     DISABLE_CANCEL(cancel_state);
 
     while (sem_wait(&si.registered) == -1) {
-#    ifdef HAIKU
-      /* To workaround some bug in Haiku semaphores.    */
-      if (EACCES == errno)
-        continue;
-#    endif
       if (errno != EINTR)
         ABORT("sem_wait failed");
     }

--- a/tests/subthreadcreate.c
+++ b/tests/subthreadcreate.c
@@ -33,10 +33,6 @@
 #    include <windows.h>
 #  endif /* !GC_PTHREADS */
 
-#  if defined(__HAIKU__)
-#    include <errno.h>
-#  endif
-
 #  include <stdlib.h>
 
 #  ifndef NTHREADS
@@ -158,13 +154,6 @@ main(void)
     if (err != 0) {
       fprintf(stderr, "Thread #%d join failed: %s\n", th_nums[i],
               strerror(err));
-#      if defined(__HAIKU__)
-      /* The error is just ignored (and the test is ended) to */
-      /* workaround some bug in Haiku pthread_join.           */
-      /* TODO: The thread is not deleted from GC_threads.     */
-      if (ESRCH == err)
-        break;
-#      endif
       exit(1);
     }
 #    else


### PR DESCRIPTION
Everything works except for forking from a thread other than the main thread; this causes crashes becaues the forked child's pthread_self() will be equivalent to the original process's main pthread_self() and thus the thread list is updated wrongly.

Changes:

 * Use B_CURRENT_TEAM (which is 0) in GC_register_dynamic_libraries, for clarity's sake.

 * Always use anonymous mmaps. Requesting memory from the standard libc allocator (via posix_memalign) just confuses things.

 * MPROTECT_VDB will not work correctly on anything other than recent nightlies, and also it's considerably slower than regular collecting, so disable it for now.

 * Remove the custom stack-base detection and just use pthread's. Also use this for the main thread rather than heuristics.

 * No need to search for "data start", all information should be reported correctly.

 * In GC_default_on_abort, invoke debugger(). This will cause the crash reason to appear in any debug reports generated (by the default system application crash dialog.)

 * Reinitialize the mark lock in fork_child_proc. It isn't legal to reuse any locks in child processes on Haiku; and the POSIX specification says that unlocking a mutex that a thread doesn't own is "undefined behavior" anyway.

 * Remove workarounds that don't seem to be needed anymore.