### PR TITLE
Avoid GC_suspend aborting due to deleted thread

### DIFF
--- a/pthread_support.c
+++ b/pthread_support.c
@@ -827,7 +827,9 @@ GC_INNER_WIN32THREAD void
 GC_delete_thread(GC_thread t)
 {
 #  if defined(GC_WIN32_THREADS) && !defined(MSWINCE)
-  CloseHandle(t->handle);
+  HANDLE handle = t->handle;
+  t->handle = NULL;
+  CloseHandle(handle);
 #  endif
 #  if !defined(GC_NO_THREADS_DISCOVERY) && defined(GC_WIN32_THREADS)
   if (GC_win32_dll_threads) {


### PR DESCRIPTION
A thread may be deleted by a DllMain call during execution of GC_suspend.

This patch sets the handle to be NULL when deleting the thread to avoid use-after-free bugs, and skips the GC_suspend attempt if the thread handle has been closed.

Fixes #704 