### PR TITLE
Avoid GC_suspend error if DllMain closes handle

### DIFF
--- a/win32_threads.c
+++ b/win32_threads.c
@@ -472,8 +472,15 @@ GC_suspend(GC_thread t)
       }
 
       /* Resume the thread, try to suspend it in a better location.   */
-      if (ResumeThread(t->handle) == (DWORD)-1)
+      if (ResumeThread(t->handle) == (DWORD)-1) {
+#    ifndef GC_NO_THREADS_DISCOVERY
+        if (NULL == GC_cptr_load_acquire(&t->handle)) {
+          GC_release_dirty_lock();
+          return;
+        }
+#    endif
         ABORT("ResumeThread failed in suspend loop");
+      }
     } else {
 #    ifndef GC_NO_THREADS_DISCOVERY
       if (NULL == GC_cptr_load_acquire(&t->handle)) {


### PR DESCRIPTION
It's possible that DllMain has set the thread handle to NULL since the SuspendThread call and that is why ResumeThread has failed. In this case, GC_suspend shouldn't abort.

This is especially problematic as it seems that sometimes the program hangs without displaying the message box. See: https://github.com/ivmai/bdwgc/issues/710#issuecomment-2707608252