### PR TITLE
Add option to disable output entirely

### DIFF
--- a/docs/README.macros
+++ b/docs/README.macros
@@ -578,6 +578,9 @@ GC_ANDROID_LOG (Android only)   Output error/debug information to Android log.
 CONSOLE_LOG (Win32 only)        Output error/debug information to stdout and
   stderr.
 
+GC_DISABLE_OUTPUT               Disable error/debug logging entirely. Useful to
+  reduce binary size but will also prevent any errors from being printed.
+
 GC_DONT_EXPAND  Do not expand the heap unless explicitly requested or forced
   to.
 


### PR DESCRIPTION
This is mostly useful in environments where printf adds a non-negligible amount of code (for example, WebAssembly in the browser). Disabling all output shrinks the binary. Of course, this option should not be used when testing/debugging the GC.

I didn't test the binary size difference on WebAssembly, but on Linux (arm64) with a statically linked musl libc the difference is 20kB in my setup.