### PR TITLE
Update for std.Build API changes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -667,8 +667,10 @@ fn addTestExt(b: *std.Build, gc: *std.Build.Step.Compile,
               filename: []const u8) void {
     const test_exe = b.addExecutable(.{
         .name = testname,
-        .optimize = gc.root_module.optimize.?,
-        .target = gc.root_module.resolved_target.?
+        .root_module = b.createModule(.{
+            .optimize = gc.root_module.optimize.?,
+            .target = gc.root_module.resolved_target.?
+        })
     });
     test_exe.addCSourceFile(.{
         .file = b.path(filename),


### PR DESCRIPTION
Implicitly creating the module was deprecated in the last release of Zig (0.14) and removed in the current 0.15-dev version. 0.14.0 is the minimum required Zig version of bdwgc so this is not a breaking change.