### PR TITLE
GC_alloc_large: increase MAX_ALLOCLARGE_RETRIES (to 10)

### DIFF
--- a/malloc.c
+++ b/malloc.c
@@ -46,7 +46,7 @@ GC_alloc_reclaim_list(struct obj_kind *ok)
 STATIC ptr_t
 GC_alloc_large(size_t lb_adjusted, int kind, unsigned flags, size_t align_m1)
 {
-#define MAX_ALLOCLARGE_RETRIES 3
+#define MAX_ALLOCLARGE_RETRIES 10
   int retry_cnt;
   size_t n_blocks; /*< includes alignment */
   struct hblk *h;


### PR DESCRIPTION
We experience _Too many retries in GC_alloc_large_ in some 32 bit programs.  Increasing `MAX_ALLOCLARGE_RETRIES` solves the problem. 

See [disclaim_bench failed because of Too many retries in GC_alloc_large](https://github.com/ivmai/bdwgc/issues/726#issuecomment-3097607685).